### PR TITLE
Change forwardauth endpoint in example compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,4 +30,4 @@ services:
       traefik.enable: true
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.dev.local`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
-      traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
+      traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -28,4 +28,4 @@ services:
       traefik.enable: true
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
-      traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
+      traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth


### PR DESCRIPTION
The current endpoint in the example compose file does not work. All documentation points to /api/auth too, so I guess it should not be /api/auth/traefik.