### PR TITLE
feat: add Remote-User header

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,3 +31,4 @@ services:
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.dev.local`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
       traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
+      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: Remote-User

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,4 +31,4 @@ services:
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.dev.local`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
       traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
-      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: Remote-User
+      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: X-Tinyauth-User

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -29,3 +29,4 @@ services:
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
       traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
+      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: Remote-User

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -29,4 +29,4 @@ services:
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
       traefik.http.services.tinyauth.loadbalancer.server.port: 3000
       traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
-      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: Remote-User
+      traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: X-Tinyauth-User

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -235,7 +235,8 @@ func (api *API) SetupRoutes() {
 				return
 			}
 
-			c.Header("Remote-User", userContext.Username)
+			// Set the user header
+			c.Header("X-Tinyauth-User", userContext.Username)
 
 			// The user is allowed to access the app
 			c.JSON(200, gin.H{

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -235,6 +235,8 @@ func (api *API) SetupRoutes() {
 				return
 			}
 
+			c.Header("Remote-User", userContext.Username)
+
 			// The user is allowed to access the app
 			c.JSON(200, gin.H{
 				"status":  200,


### PR DESCRIPTION
This PR adds a really simple Remote-User header feature.

Allowing traefik to formard the Remote-User header, the service proxied will be able to read from it and potentially authenticate the user inside the header.

I tested it with Zitadel as a Generic OAuth provider with a scope "email" and Firefly-III.