### PR TITLE
Update whoami router name in docker-compose.example.yml to make it easier to understand

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,8 +13,8 @@ services:
     image: traefik/whoami:latest
     labels:
       traefik.enable: true
-      traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
-      traefik.http.routers.nginx.middlewares: tinyauth
+      traefik.http.routers.whoami.rule: Host(`whoami.example.com`)
+      traefik.http.routers.whoami.middlewares: tinyauth
 
   tinyauth:
     container_name: tinyauth


### PR DESCRIPTION
Any router name works as long as it is consistently applied. The `nginx` name for the `whoami` container route can be a bit confusing for new users. Aligning the container and route name is similar to how Traefik generates dynamic routes, makes it easier to read the compose file and logs, and can generally help reduce bugs when extending the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example Docker Compose configuration to use consistent router naming for the whoami service, improving clarity and reducing setup confusion.
  * Maintains the same host configuration; no behavioral changes expected.
  * Change is isolated to the whoami example; other services and configurations remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->