### PR TITLE
Update verify.go

### DIFF
--- a/cmd/user/verify/verify.go
+++ b/cmd/user/verify/verify.go
@@ -70,7 +70,7 @@ var VerifyCmd = &cobra.Command{
 
 		err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(iPassword))
 		if err != nil {
-			log.Fatal().Msg("Ppassword is incorrect")
+			log.Fatal().Msg("Password is incorrect")
 		}
 
 		if user.TotpSecret == "" {


### PR DESCRIPTION
Fix typo,
`Ppassword is incorrect` becomes `Password is incorrect`