### PR TITLE
Update some workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,38 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2.0.2
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
-          go-version: "^1.23.2"
-
-      - name: Install frontend dependencies
-        run: |
-          cd frontend
-          bun install
+          go-version: '1.25'
 
       - name: Set version
-        run: |
-          echo testing > internal/assets/version
+        run: echo testing > internal/assets/version
 
-      - name: Build frontend
+      - name: Install, build & copy frontend assets
+        working-directory: ./frontend
         run: |
-          cd frontend
+          bun install
           bun run build
-
-      - name: Copy frontend
-        run: |
-          cp -r frontend/dist internal/assets/dist
+          cp -r ./dist ../internal/assets/dist
 
       - name: Run tests
         run: go test -coverprofile=coverage.txt -v ./...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/digestabot.yml
+++ b/.github/workflows/digestabot.yml
@@ -1,0 +1,26 @@
+---
+name: Docker image digests update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  image-update:
+    name: Docker image digests update
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Update Docker image digests
+        uses: chainguard-dev/digestabot@a3b776c1ca57d3127c85578cde8fef6eed3c75d3  # v1.2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+...

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -6,11 +6,11 @@ jobs:
   generate-sponsors:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Generate Sponsors
-        uses: JamesIves/github-sponsors-readme-action@v1
+        uses: JamesIves/github-sponsors-readme-action@1a120c92d5067dafeaedb33916301fd61338883d  # v1.5.6
         with:
           token: ${{ secrets.SPONSORS_GENERATOR_PAT }}
           active-only: false
@@ -18,7 +18,7 @@ jobs:
           template: '<a href="https://github.com/{{{ login }}}"><img src="{{{ avatarUrl }}}" width="64px" alt="User avatar: {{{ login }}}" /></a>&nbsp;&nbsp;'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f  # v10.0.0
         with:
           days-before-stale: 30
           stale-pr-message: This PR has been inactive for 30 days and will be marked as stale.


### PR DESCRIPTION
this pr updates some of the workflows

- use digests for most github actions (will look at nightly and release later)
- add workflow for updating docker image digests
- simplified ci workflow a bit
- enabled dependabot updates for github actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Pinned GitHub Actions to specific commit SHAs for improved reliability.
  - Added Dependabot configuration to auto-update GitHub Actions daily.
  - Introduced a scheduled workflow to automatically refresh Docker image digests.
  - Updated CI to Go 1.25 and streamlined frontend build to install, build, and copy assets in one step with a new asset path.
  - Aligned sponsors and stale workflows with pinned action versions and minor naming tweaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->