### PR TITLE
feat: add http cache for static files

### DIFF
--- a/internal/middleware/ui_middleware.go
+++ b/internal/middleware/ui_middleware.go
@@ -1,10 +1,12 @@
 package middleware
 
 import (
+	"fmt"
 	"io/fs"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 	"tinyauth/internal/assets"
 
 	"github.com/gin-gonic/gin"
@@ -27,14 +29,16 @@ func (m *UIMiddleware) Init() error {
 	}
 
 	m.uiFs = ui
-	m.uiFileServer = http.FileServer(http.FS(ui))
+	m.uiFileServer = http.FileServerFS(ui)
 
 	return nil
 }
 
 func (m *UIMiddleware) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		switch strings.Split(c.Request.URL.Path, "/")[1] {
+		path := strings.TrimPrefix(c.Request.URL.Path, "/")
+
+		switch strings.SplitN(path, "/", 2)[0] {
 		case "api":
 			c.Next()
 			return
@@ -42,12 +46,19 @@ func (m *UIMiddleware) Middleware() gin.HandlerFunc {
 			c.Next()
 			return
 		default:
-			_, err := fs.Stat(m.uiFs, strings.TrimPrefix(c.Request.URL.Path, "/"))
+			_, err := fs.Stat(m.uiFs, path)
+
+			// Enough for one authentication flow
+			maxAge := 15 * time.Minute
 
 			if os.IsNotExist(err) {
 				c.Request.URL.Path = "/"
+			} else if strings.HasPrefix(path, "assets/") {
+				// assets are named with a hash and can be cached for a long time
+				maxAge = 30 * 24 * time.Hour
 			}
 
+			c.Writer.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", maxAge.Seconds()))
 			m.uiFileServer.ServeHTTP(c.Writer, c.Request)
 			c.Abort()
 			return

--- a/internal/middleware/ui_middleware.go
+++ b/internal/middleware/ui_middleware.go
@@ -58,7 +58,7 @@ func (m *UIMiddleware) Middleware() gin.HandlerFunc {
 				maxAge = 30 * 24 * time.Hour
 			}
 
-			c.Writer.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", maxAge.Seconds()))
+			c.Writer.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(maxAge.Seconds())))
 			m.uiFileServer.ServeHTTP(c.Writer, c.Request)
 			c.Abort()
 			return


### PR DESCRIPTION
fix #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Faster page loads with smarter caching: UI assets cached up to 30 days; other files for 15 minutes.
  - Added Cache-Control headers for better browser and CDN performance.
  - More robust path handling for UI resources.

- Bug Fixes
  - Reduced 404s by normalizing paths before serving files.
  - Unknown routes now correctly fall back to the root path, improving SPA navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->