### PR TITLE
fix: allow root cookie domain host redirects

### DIFF
--- a/internal/utils/app_utils.go
+++ b/internal/utils/app_utils.go
@@ -100,17 +100,17 @@ func IsRedirectSafe(redirectURL string, domain string) bool {
 		return false
 	}
 
-	cookieDomain, err := GetCookieDomain(redirectURL)
+	host := parsedURL.Hostname()
+	if host == domain {
+		return true
+	}
 
+	cookieDomain, err := GetCookieDomain(redirectURL)
 	if err != nil {
 		return false
 	}
 
-	if cookieDomain != domain {
-		return false
-	}
-
-	return true
+	return cookieDomain == domain
 }
 
 func GetLogLevel(level string) zerolog.Level {

--- a/internal/utils/app_utils_test.go
+++ b/internal/utils/app_utils_test.go
@@ -164,7 +164,7 @@ func TestIsRedirectSafe(t *testing.T) {
 	// Case with no subdomain
 	redirectURL := "http://example.com/welcome"
 	result := utils.IsRedirectSafe(redirectURL, domain)
-	assert.Equal(t, false, result)
+	assert.Equal(t, true, result)
 
 	// Case with different domain
 	redirectURL = "http://malicious.com/phishing"
@@ -199,6 +199,41 @@ func TestIsRedirectSafe(t *testing.T) {
 	// Case with URL having different TLD
 	redirectURL = "http://example.org/page"
 	result = utils.IsRedirectSafe(redirectURL, domain)
+	assert.Equal(t, false, result)
+}
+
+func TestIsRedirectSafeMultiLevel(t *testing.T) {
+	// Setup
+	cookieDomain := "tinyauth.example.com"
+
+	// Case with 3rd level domain
+	redirectURL := "http://tinyauth.example.com/welcome"
+	result := utils.IsRedirectSafe(redirectURL, cookieDomain)
+	assert.Equal(t, true, result)
+
+	// Case with root domain
+	redirectURL = "http://example.com/unsafe"
+	result = utils.IsRedirectSafe(redirectURL, cookieDomain)
+	assert.Equal(t, false, result)
+
+	// Case with 4th level domain
+	redirectURL = "http://auth.tinyauth.example.com/post-login"
+	result = utils.IsRedirectSafe(redirectURL, cookieDomain)
+	assert.Equal(t, true, result)
+
+	// Case with 5th level domain (should be unsafe)
+	redirectURL = "http://x.auth.tinyauth.example.com/deep"
+	result = utils.IsRedirectSafe(redirectURL, cookieDomain)
+	assert.Equal(t, false, result)
+
+	// Case with different subdomain
+	redirectURL = "http://auth.tinyauth.example.net/attack"
+	result = utils.IsRedirectSafe(redirectURL, cookieDomain)
+	assert.Equal(t, false, result)
+
+	// Case with malformed URL
+	redirectURL = "http://[::1]:namedport"
+	result = utils.IsRedirectSafe(redirectURL, cookieDomain)
 	assert.Equal(t, false, result)
 }
 


### PR DESCRIPTION
Fixes #408 

Previously IsRedirectSafe rejected redirects to the exact cookie domain when AppURL had multiple subdomain levels, because it stripped the first label twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect validation: destinations that exactly match the expected host or derive from its cookie domain are now correctly allowed, fixing root-domain redirect handling and making subdomain decisions more consistent.

* **Tests**
  * Expanded test coverage for multi-level subdomains and malformed URLs to verify corrected redirect behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->