### PR TITLE
database: Show additional warning when sqlite file cannot be opened

### DIFF
--- a/internal/service/database_service.go
+++ b/internal/service/database_service.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"tinyauth/internal/assets"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/glebarez/sqlite"
 	"github.com/golang-migrate/migrate/v4"
 	sqliteMigrate "github.com/golang-migrate/migrate/v4/database/sqlite3"
@@ -30,6 +32,7 @@ func (ds *DatabaseService) Init() error {
 	gormDB, err := gorm.Open(sqlite.Open(ds.config.DatabasePath), &gorm.Config{})
 
 	if err != nil {
+		log.Warn().Err(err).Str("database_path", ds.config.DatabasePath).Msg("Unable to open database")
 		return err
 	}
 


### PR DESCRIPTION
Currently, when database file cannot be created and opened, we get the following confusing error:
"failed to initialize database service: unable to open database file: out of memory (14)"

Unfortunately, the real error is either in Go's SQLite library or the ORM library as SQLite's errno=14 is `SQLITE_CANTOPEN`, based on https://sqlite.org/rescode.html#cantopen

For now, the best thing we can do is show a better though still somewhat confusing error message ourselves, until someone manages to figure out the real cause for this confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal error logging for database connection issues to improve troubleshooting and diagnostic capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->