### PR TITLE
feat: auto-create database directory if missing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func (c *rootCmd) Register() {
 		{"ldap-insecure", false, "Skip certificate verification for the LDAP server."},
 		{"ldap-search-filter", "(uid=%s)", "LDAP search filter for user lookup."},
 		{"resources-dir", "/data/resources", "Path to a directory containing custom resources (e.g. background image)."},
-		{"database-path", "/data/tinyauth.db", "Path to the Sqlite database file."},
+		{"database-path", "/data/tinyauth.db", "Path to the Sqlite database file. Directory will be created if it doesn't exist."},
 		{"trusted-proxies", "", "Comma separated list of trusted proxies (IP addresses or CIDRs) for correct client IP detection."},
 		{"disable-analytics", false, "Disable anonymous version collection."},
 		{"disable-resources", false, "Disable the resources server."},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	LdapInsecure          bool   `mapstructure:"ldap-insecure"`
 	LdapSearchFilter      string `mapstructure:"ldap-search-filter"`
 	ResourcesDir          string `mapstructure:"resources-dir"`
-	DatabasePath          string `mapstructure:"database-path" validate:"required"`
+	DatabasePath          string `mapstructure:"database-path"`
 	TrustedProxies        string `mapstructure:"trusted-proxies"`
 	DisableAnalytics      bool   `mapstructure:"disable-analytics"`
 	DisableResources      bool   `mapstructure:"disable-resources"`

--- a/internal/service/database_service.go
+++ b/internal/service/database_service.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
 	"tinyauth/internal/assets"
 
 	"github.com/glebarez/sqlite"
@@ -27,7 +30,17 @@ func NewDatabaseService(config DatabaseServiceConfig) *DatabaseService {
 }
 
 func (ds *DatabaseService) Init() error {
-	gormDB, err := gorm.Open(sqlite.Open(ds.config.DatabasePath), &gorm.Config{})
+	dbPath := ds.config.DatabasePath
+	if dbPath == "" {
+		dbPath = "/data/tinyauth.db"
+	}
+
+	dir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create database directory %s: %w", dir, err)
+	}
+
+	gormDB, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

When `DATABASE_PATH` is not set or points to a non-existent directory, TinyAuth v4 fails to start with a confusing error message ("out of memory (14)"). This is problematic in Docker deployments where users expect the application to work out of the box.

## Solution

Auto-create the database directory if it doesn't exist and provide a sensible default (`/data/tinyauth.db`) when `DATABASE_PATH` is empty. This works seamlessly with any Docker volume configuration.

## Changes

- Auto-create database directory using `os.MkdirAll` (handles multi-level paths)
- Default to `/data/tinyauth.db` when `DATABASE_PATH` is empty
- Remove `validate:"required"` to allow flexibility

## Behavior

- **No volume**: Directory created in container (ephemeral with anonymous volumes)
- **Volume mounted**: Directory created in volume (persistent)
- **Custom path**: Directory auto-created at specified path
- **Backward compatible**: Existing configs continue to work

## Testing

✅ Code compiles successfully (tested with Docker build)  
✅ Follows existing code patterns  
✅ Backward compatible  
✅ Handles multi-level directory paths  
✅ No linter errors

## Related

Related to [PR #506](https://github.com/steveiliop56/tinyauth/pull/506) which improves error messages when database cannot be opened. This PR fixes the root cause by auto-creating the directory, preventing the error from occurring in the first place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Database directory will now be automatically created during initialization if it doesn't exist.
  * Database path is now optional with a sensible default location.
  * Updated help documentation to reflect automatic directory creation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->