### PR TITLE
fix: allow any HTTP method for /api/auth/envoy

### DIFF
--- a/internal/controller/proxy_controller.go
+++ b/internal/controller/proxy_controller.go
@@ -74,6 +74,7 @@ func (controller *ProxyController) proxyHandler(c *gin.Context) {
 	// so we allow Any standard HTTP method for /api/auth/envoy
 	if req.Proxy != "envoy" && c.Request.Method != http.MethodGet {
 		log.Warn().Str("method", c.Request.Method).Msg("Invalid method for proxy")
+		c.Header("Allow", "GET")
 		c.JSON(405, gin.H{
 			"status":  405,
 			"message": "Method Not Allowed",

--- a/internal/controller/proxy_controller_test.go
+++ b/internal/controller/proxy_controller_test.go
@@ -87,6 +87,7 @@ func TestProxyHandler(t *testing.T) {
 	router.ServeHTTP(recorder, req)
 
 	assert.Equal(t, 405, recorder.Code)
+	assert.Equal(t, "GET", recorder.Header().Get("Allow"))
 
 	// Test logged out user (traefik/caddy)
 	recorder = httptest.NewRecorder()


### PR DESCRIPTION
Re-introduces changes that were reverted in https://github.com/steveiliop56/tinyauth/pull/540. Envoy endpoint must respond on any standard HTTP methods. Added better code comments for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter HTTP method handling for authentication proxies: non-envoy proxies are limited to GET and now return 405 with Allow header for unsupported methods; envoy proxies retain broader method handling and existing redirect behavior.

* **Tests**
  * Expanded test coverage to validate 405 responses and Allow header for non-envoy proxies, plus envoy POST/DELETE redirect scenarios for unauthenticated requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->