### PR TITLE
fix: username provider appearing when no auth is configured

### DIFF
--- a/internal/bootstrap/service_bootstrap.go
+++ b/internal/bootstrap/service_bootstrap.go
@@ -67,7 +67,7 @@ func (app *BootstrapApp) initServices(queries *repository.Queries) (Services, er
 		LoginTimeout:       app.config.Auth.LoginTimeout,
 		LoginMaxRetries:    app.config.Auth.LoginMaxRetries,
 		SessionCookieName:  app.context.sessionCookieName,
-	}, dockerService, ldapService, queries)
+	}, dockerService, services.ldapService, queries)
 
 	err = authService.Init()
 


### PR DESCRIPTION
 _AI Summary_

Fixes a bug where the username authentication provider would incorrectly appear in the login UI when neither local users nor LDAP were successfully configured, but only OAuth providers were set up.

**Root Cause:** When LDAP initialization failed, a non-nil (but uninitialized) LDAP service was being passed to AuthService, causing `UserAuthConfigured()` to return true.

**Fix:** Pass `services.ldapService` (which is nil when init fails) instead of the local `ldapService` variable to AuthService constructor in service_bootstrap.go line 69.

**Impact:** Username provider now only appears when users are configured or LDAP successfully initializes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal service initialization logic for better code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->