### PR TITLE
fix(frontend): Add flag to check auto-redirect

### DIFF
--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -46,6 +46,7 @@ export const LoginPage = () => {
 
   const redirectTimer = useRef<number | null>(null);
   const redirectButtonTimer = useRef<number | null>(null);
+  const hasAutoRedirected = useRef(false);
 
   const searchParams = new URLSearchParams(search);
   const {
@@ -79,6 +80,7 @@ export const LoginPage = () => {
     },
     onError: () => {
       setOauthAutoRedirectHandover(false);
+      hasAutoRedirected.current = false;
       toast.error(t("loginOauthFailTitle"), {
         description: t("loginOauthFailSubtitle"),
       });
@@ -122,10 +124,12 @@ export const LoginPage = () => {
 
   useEffect(() => {
     if (
+      !hasAutoRedirected.current &&
       providers.find((provider) => provider.id === oauthAutoRedirect) &&
       !isLoggedIn &&
       props.redirect_uri !== ""
     ) {
+      hasAutoRedirected.current = true;
       // Not sure of a better way to do this
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setOauthAutoRedirectHandover(true);
@@ -139,7 +143,7 @@ export const LoginPage = () => {
     isLoggedIn,
     props.redirect_uri,
     oauthAutoRedirect,
-    oauthMutation,
+    oauthMutation.mutate, // stable reference per TanStack Query
   ]);
 
   useEffect(
@@ -233,7 +237,7 @@ export const LoginPage = () => {
             loading={loginMutation.isPending || oauthMutation.isPending}
           />
         )}
-        {providers.length == 0 && (
+        {providers.length === 0 && (
           <p className="text-center text-red-600 max-w-sm">
             {t("failedToFetchProvidersTitle")}
           </p>


### PR DESCRIPTION
The [useEffect](https://github.com/contre95/tinyauth/blob/3bf8c62542c6204518c4e5543110df723abdacf5/frontend/src/pages/login-page.tsx?plain=1#L125) hook had a dependency on [oauthMutation](https://github.com/contre95/tinyauth/blob/3bf8c62542c6204518c4e5543110df723abdacf5/frontend/src/pages/login-page.tsx?plain=1#L136), which changes every time the mutation runs. This caused the effect to re-run indefinitely, creating hundreds of requests to  the OIDC provider, in this case`/api/oauth/url/pocketid`.

This is happening only in `tinyauth:nightly` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of OAuth auto-redirect flow during login to prevent duplicate redirect attempts.
  * Enhanced error handling to ensure proper recovery from OAuth authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->