### PR TITLE
feat: extract OAuth groups from ID token when userinfo omits them

### DIFF
--- a/internal/assets/migrations/000007_refresh_token.down.sql
+++ b/internal/assets/migrations/000007_refresh_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" DROP COLUMN "refresh_token";

--- a/internal/assets/migrations/000007_refresh_token.up.sql
+++ b/internal/assets/migrations/000007_refresh_token.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN "refresh_token" TEXT NULL;

--- a/internal/bootstrap/service_bootstrap.go
+++ b/internal/bootstrap/service_bootstrap.go
@@ -90,6 +90,9 @@ func (app *BootstrapApp) initServices(queries *repository.Queries) (Services, er
 
 	services.oauthBrokerService = oauthBrokerService
 
+	// Wire up OAuth broker to auth service for group refresh functionality
+	authService.SetOAuthBroker(oauthBrokerService)
+
 	oidcService := service.NewOIDCService(service.OIDCServiceConfig{
 		Clients:        app.config.OIDC.Clients,
 		PrivateKeyPath: app.config.OIDC.PrivateKeyPath,

--- a/internal/controller/oauth_controller.go
+++ b/internal/controller/oauth_controller.go
@@ -125,7 +125,7 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 	c.SetCookie(controller.config.CSRFCookieName, "", -1, "/", fmt.Sprintf(".%s", controller.config.CookieDomain), controller.config.SecureCookie, true)
 
 	code := c.Query("code")
-	service, exists := controller.broker.GetService(req.Provider)
+	oauthService, exists := controller.broker.GetService(req.Provider)
 
 	if !exists {
 		tlog.App.Warn().Msgf("OAuth provider not found: %s", req.Provider)
@@ -133,7 +133,7 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 		return
 	}
 
-	err = service.VerifyCode(code)
+	err = oauthService.VerifyCode(code)
 	if err != nil {
 		tlog.App.Error().Err(err).Msg("Failed to verify OAuth code")
 		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/error", controller.config.AppURL))
@@ -192,14 +192,22 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 		username = strings.Replace(user.Email, "@", "_", 1)
 	}
 
+	// Extract refresh token from the OAuth token (if available)
+	var refreshToken string
+	if token := oauthService.GetToken(); token != nil && token.RefreshToken != "" {
+		refreshToken = token.RefreshToken
+		tlog.App.Debug().Msg("Storing refresh token for session")
+	}
+
 	sessionCookie := repository.Session{
-		Username:    username,
-		Name:        name,
-		Email:       user.Email,
-		Provider:    req.Provider,
-		OAuthGroups: utils.CoalesceToString(user.Groups),
-		OAuthName:   service.GetName(),
-		OAuthSub:    user.Sub,
+		Username:     username,
+		Name:         name,
+		Email:        user.Email,
+		Provider:     req.Provider,
+		OAuthGroups:  utils.CoalesceToString(user.Groups),
+		OAuthName:    oauthService.GetName(),
+		OAuthSub:     user.Sub,
+		RefreshToken: refreshToken,
 	}
 
 	tlog.App.Trace().Interface("session_cookie", sessionCookie).Msg("Creating session cookie")

--- a/internal/controller/proxy_controller.go
+++ b/internal/controller/proxy_controller.go
@@ -217,6 +217,35 @@ func (controller *ProxyController) proxyHandler(c *gin.Context) {
 
 			if userContext.OAuth {
 				groupOK = controller.auth.IsInOAuthGroup(c, userContext, acls.OAuth.Groups)
+				
+				// If group check failed, attempt to refresh groups using the refresh token (max 1 retry)
+				if !groupOK && acls.OAuth.Groups != "" {
+					tlog.App.Debug().Str("user", userContext.Email).Msg("Group check failed, attempting token refresh")
+					
+					// Get the session to access the refresh token
+					session, err := controller.auth.GetSessionCookie(c)
+					if err == nil && session.RefreshToken != "" {
+						// Attempt to refresh groups
+						newGroups, err := controller.auth.RefreshOAuthGroups(c, session)
+						if err == nil {
+							// Re-check with the new groups
+							userContext.OAuthGroups = newGroups
+							groupOK = controller.auth.IsInOAuthGroup(c, userContext, acls.OAuth.Groups)
+							
+							if groupOK {
+								tlog.App.Info().Str("user", userContext.Email).Str("resource", strings.Split(host, ".")[0]).Msg("Access granted after group refresh")
+							} else {
+								tlog.App.Debug().Str("user", userContext.Email).Msg("Group check still failed after refresh")
+							}
+						} else {
+							tlog.App.Warn().Err(err).Str("user", userContext.Email).Msg("Failed to refresh OAuth groups")
+						}
+					} else if err != nil {
+						tlog.App.Debug().Err(err).Msg("Could not get session for group refresh")
+					} else {
+						tlog.App.Debug().Msg("No refresh token available for group refresh")
+					}
+				}
 			} else {
 				groupOK = controller.auth.IsInLdapGroup(c, userContext, acls.LDAP.Groups)
 			}

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -35,15 +35,16 @@ type OidcUserinfo struct {
 }
 
 type Session struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	RefreshToken string
 }

--- a/internal/repository/session_queries.sql.go
+++ b/internal/repository/session_queries.sql.go
@@ -21,25 +21,27 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "refresh_token"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, refresh_token
 `
 
 type CreateSessionParams struct {
-	UUID        string
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	CreatedAt   int64
-	OAuthName   string
-	OAuthSub    string
+	UUID         string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	CreatedAt    int64
+	OAuthName    string
+	OAuthSub     string
+	RefreshToken string
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error) {
@@ -55,6 +57,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		arg.CreatedAt,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.RefreshToken,
 	)
 	var i Session
 	err := row.Scan(
@@ -69,6 +72,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.RefreshToken,
 	)
 	return i, err
 }
@@ -94,7 +98,7 @@ func (q *Queries) DeleteSession(ctx context.Context, uuid string) error {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub FROM "sessions"
+SELECT uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, refresh_token FROM "sessions"
 WHERE "uuid" = ?
 `
 
@@ -113,6 +117,7 @@ func (q *Queries) GetSession(ctx context.Context, uuid string) (Session, error) 
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.RefreshToken,
 	)
 	return i, err
 }
@@ -127,22 +132,24 @@ UPDATE "sessions" SET
     "oauth_groups" = ?,
     "expiry" = ?,
     "oauth_name" = ?,
-    "oauth_sub" = ?
+    "oauth_sub" = ?,
+    "refresh_token" = ?
 WHERE "uuid" = ?
-RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, refresh_token
 `
 
 type UpdateSessionParams struct {
-	Username    string
-	Email       string
-	Name        string
-	Provider    string
-	TotpPending bool
-	OAuthGroups string
-	Expiry      int64
-	OAuthName   string
-	OAuthSub    string
-	UUID        string
+	Username     string
+	Email        string
+	Name         string
+	Provider     string
+	TotpPending  bool
+	OAuthGroups  string
+	Expiry       int64
+	OAuthName    string
+	OAuthSub     string
+	RefreshToken string
+	UUID         string
 }
 
 func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error) {
@@ -156,6 +163,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		arg.Expiry,
 		arg.OAuthName,
 		arg.OAuthSub,
+		arg.RefreshToken,
 		arg.UUID,
 	)
 	var i Session
@@ -171,6 +179,45 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		&i.CreatedAt,
 		&i.OAuthName,
 		&i.OAuthSub,
+		&i.RefreshToken,
+	)
+	return i, err
+}
+
+const updateSessionGroups = `-- name: UpdateSessionGroups :one
+UPDATE "sessions" SET
+    "oauth_groups" = ?,
+    "refresh_token" = ?
+WHERE "uuid" = ?
+RETURNING uuid, username, email, name, provider, totp_pending, oauth_groups, expiry, created_at, oauth_name, oauth_sub, refresh_token
+`
+
+type UpdateSessionGroupsParams struct {
+	OAuthGroups  string
+	RefreshToken string
+	UUID         string
+}
+
+func (q *Queries) UpdateSessionGroups(ctx context.Context, arg UpdateSessionGroupsParams) (Session, error) {
+	row := q.db.QueryRowContext(ctx, updateSessionGroups,
+		arg.OAuthGroups,
+		arg.RefreshToken,
+		arg.UUID,
+	)
+	var i Session
+	err := row.Scan(
+		&i.UUID,
+		&i.Username,
+		&i.Email,
+		&i.Name,
+		&i.Provider,
+		&i.TotpPending,
+		&i.OAuthGroups,
+		&i.Expiry,
+		&i.CreatedAt,
+		&i.OAuthName,
+		&i.OAuthSub,
+		&i.RefreshToken,
 	)
 	return i, err
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -53,6 +53,7 @@ type AuthService struct {
 	ldapGroupsMutex sync.RWMutex
 	ldap            *LdapService
 	queries         *repository.Queries
+	oauthBroker     *OAuthBrokerService
 }
 
 func NewAuthService(config AuthServiceConfig, docker *DockerService, ldap *LdapService, queries *repository.Queries) *AuthService {
@@ -64,6 +65,11 @@ func NewAuthService(config AuthServiceConfig, docker *DockerService, ldap *LdapS
 		ldap:            ldap,
 		queries:         queries,
 	}
+}
+
+// SetOAuthBroker sets the OAuth broker service (called after initialization to avoid circular dependency)
+func (auth *AuthService) SetOAuthBroker(broker *OAuthBrokerService) {
+	auth.oauthBroker = broker
 }
 
 func (auth *AuthService) Init() error {
@@ -250,17 +256,18 @@ func (auth *AuthService) CreateSessionCookie(c *gin.Context, data *repository.Se
 	}
 
 	session := repository.CreateSessionParams{
-		UUID:        uuid.String(),
-		Username:    data.Username,
-		Email:       data.Email,
-		Name:        data.Name,
-		Provider:    data.Provider,
-		TotpPending: data.TotpPending,
-		OAuthGroups: data.OAuthGroups,
-		Expiry:      time.Now().Add(time.Duration(expiry) * time.Second).Unix(),
-		CreatedAt:   time.Now().Unix(),
-		OAuthName:   data.OAuthName,
-		OAuthSub:    data.OAuthSub,
+		UUID:         uuid.String(),
+		Username:     data.Username,
+		Email:        data.Email,
+		Name:         data.Name,
+		Provider:     data.Provider,
+		TotpPending:  data.TotpPending,
+		OAuthGroups:  data.OAuthGroups,
+		Expiry:       time.Now().Add(time.Duration(expiry) * time.Second).Unix(),
+		CreatedAt:    time.Now().Unix(),
+		OAuthName:    data.OAuthName,
+		OAuthSub:     data.OAuthSub,
+		RefreshToken: data.RefreshToken,
 	}
 
 	_, err = auth.queries.CreateSession(c, session)
@@ -304,16 +311,17 @@ func (auth *AuthService) RefreshSessionCookie(c *gin.Context) error {
 	newExpiry := session.Expiry + refreshThreshold
 
 	_, err = auth.queries.UpdateSession(c, repository.UpdateSessionParams{
-		Username:    session.Username,
-		Email:       session.Email,
-		Name:        session.Name,
-		Provider:    session.Provider,
-		TotpPending: session.TotpPending,
-		OAuthGroups: session.OAuthGroups,
-		Expiry:      newExpiry,
-		OAuthName:   session.OAuthName,
-		OAuthSub:    session.OAuthSub,
-		UUID:        session.UUID,
+		Username:     session.Username,
+		Email:        session.Email,
+		Name:         session.Name,
+		Provider:     session.Provider,
+		TotpPending:  session.TotpPending,
+		OAuthGroups:  session.OAuthGroups,
+		Expiry:       newExpiry,
+		OAuthName:    session.OAuthName,
+		OAuthSub:     session.OAuthSub,
+		RefreshToken: session.RefreshToken,
+		UUID:         session.UUID,
 	})
 
 	if err != nil {
@@ -380,17 +388,7 @@ func (auth *AuthService) GetSessionCookie(c *gin.Context) (repository.Session, e
 		return repository.Session{}, fmt.Errorf("session expired")
 	}
 
-	return repository.Session{
-		UUID:        session.UUID,
-		Username:    session.Username,
-		Email:       session.Email,
-		Name:        session.Name,
-		Provider:    session.Provider,
-		TotpPending: session.TotpPending,
-		OAuthGroups: session.OAuthGroups,
-		OAuthName:   session.OAuthName,
-		OAuthSub:    session.OAuthSub,
-	}, nil
+	return session, nil
 }
 
 func (auth *AuthService) LocalAuthConfigured() bool {
@@ -552,4 +550,60 @@ func (auth *AuthService) IsBypassedIP(acls config.AppIP, ip string) bool {
 
 	tlog.App.Debug().Str("ip", ip).Msg("IP not in bypass list, continuing with authentication")
 	return false
+}
+
+// RefreshOAuthGroups attempts to use a stored refresh token to get updated group membership.
+// Returns the new groups string and optionally updates the session in the database.
+// This is used when a user's group membership may have changed since they logged in.
+func (auth *AuthService) RefreshOAuthGroups(c *gin.Context, session repository.Session) (string, error) {
+	if session.RefreshToken == "" {
+		return "", fmt.Errorf("no refresh token available for session")
+	}
+
+	if auth.oauthBroker == nil {
+		return "", fmt.Errorf("OAuth broker not configured")
+	}
+
+	// Get the OAuth service for this provider
+	oauthService, exists := auth.oauthBroker.GetService(session.Provider)
+	if !exists {
+		return "", fmt.Errorf("OAuth provider not found: %s", session.Provider)
+	}
+
+	// Attempt to refresh the token
+	newToken, err := oauthService.RefreshToken(session.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to refresh OAuth token: %w", err)
+	}
+
+	// Extract groups from the new ID token
+	groups, err := ExtractGroupsFromToken(newToken)
+	if err != nil {
+		tlog.App.Warn().Err(err).Msg("Failed to extract groups from refreshed token")
+		return "", fmt.Errorf("failed to extract groups from refreshed token: %w", err)
+	}
+
+	// Convert groups to string
+	groupsStr := utils.CoalesceToString(groups)
+
+	// Get the new refresh token (may have rotated)
+	newRefreshToken := newToken.RefreshToken
+	if newRefreshToken == "" {
+		// Keep the old one if no new one was provided
+		newRefreshToken = session.RefreshToken
+	}
+
+	// Update the session in the database with new groups and refresh token
+	_, err = auth.queries.UpdateSessionGroups(c, repository.UpdateSessionGroupsParams{
+		OAuthGroups:  groupsStr,
+		RefreshToken: newRefreshToken,
+		UUID:         session.UUID,
+	})
+	if err != nil {
+		tlog.App.Error().Err(err).Msg("Failed to update session groups in database")
+		// Still return the new groups even if DB update failed
+	}
+
+	tlog.App.Info().Str("user", session.Email).Msg("Successfully refreshed OAuth groups")
+	return groupsStr, nil
 }

--- a/internal/service/generic_oauth_service.go
+++ b/internal/service/generic_oauth_service.go
@@ -172,3 +172,39 @@ func parseIDTokenGroups(idToken string) (any, error) {
 func (generic *GenericOAuthService) GetName() string {
 	return generic.name
 }
+
+// GetToken returns the current OAuth token (after VerifyCode has been called)
+func (generic *GenericOAuthService) GetToken() *oauth2.Token {
+	return generic.token
+}
+
+// RefreshToken uses a refresh token to get a new access/ID token.
+// Returns a new token containing potentially updated id_token with fresh groups.
+func (generic *GenericOAuthService) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("no refresh token provided")
+	}
+
+	// Create a token source using the refresh token
+	oldToken := &oauth2.Token{
+		RefreshToken: refreshToken,
+	}
+
+	tokenSource := generic.config.TokenSource(generic.context, oldToken)
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	tlog.App.Debug().Msg("Successfully refreshed OAuth token")
+	return newToken, nil
+}
+
+// ExtractGroupsFromToken extracts groups from an OAuth token's id_token
+func ExtractGroupsFromToken(token *oauth2.Token) (any, error) {
+	idTokenStr, ok := token.Extra("id_token").(string)
+	if !ok || idTokenStr == "" {
+		return nil, fmt.Errorf("no id_token in token response")
+	}
+	return parseIDTokenGroups(idTokenStr)
+}

--- a/internal/service/generic_oauth_service.go
+++ b/internal/service/generic_oauth_service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/steveiliop56/tinyauth/internal/config"
@@ -124,7 +125,48 @@ func (generic *GenericOAuthService) Userinfo() (config.Claims, error) {
 		return user, err
 	}
 
+	// If the userinfo endpoint did not return groups (e.g. Microsoft Entra ID),
+	// try to extract them from the ID token which may contain a "groups" claim.
+	if user.Groups == nil {
+		if idTokenStr, ok := generic.token.Extra("id_token").(string); ok && idTokenStr != "" {
+			if groups, err := parseIDTokenGroups(idTokenStr); err == nil {
+				tlog.App.Debug().Msg("Extracted groups from ID token (userinfo had none)")
+				user.Groups = groups
+			} else {
+				tlog.App.Debug().Err(err).Msg("Could not extract groups from ID token")
+			}
+		}
+	}
+
 	return user, nil
+}
+
+// parseIDTokenGroups decodes the payload of a JWT ID token and extracts the
+// "groups" claim. The token signature is not verified here because the token
+// was received directly from the token endpoint over TLS in the same request.
+func parseIDTokenGroups(idToken string) (any, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Groups any `json:"groups"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+
+	if claims.Groups == nil {
+		return nil, fmt.Errorf("no groups claim in ID token")
+	}
+
+	return claims.Groups, nil
 }
 
 func (generic *GenericOAuthService) GetName() string {

--- a/internal/service/github_oauth_service.go
+++ b/internal/service/github_oauth_service.go
@@ -182,3 +182,13 @@ func (github *GithubOAuthService) Userinfo() (config.Claims, error) {
 func (github *GithubOAuthService) GetName() string {
 	return github.name
 }
+
+// GetToken returns the current OAuth token (after VerifyCode has been called)
+func (github *GithubOAuthService) GetToken() *oauth2.Token {
+	return github.token
+}
+
+// RefreshToken is not supported for GitHub OAuth (no group-based ACLs)
+func (github *GithubOAuthService) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("token refresh not supported for GitHub OAuth")
+}

--- a/internal/service/google_oauth_service.go
+++ b/internal/service/google_oauth_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,4 +114,14 @@ func (google *GoogleOAuthService) Userinfo() (config.Claims, error) {
 
 func (google *GoogleOAuthService) GetName() string {
 	return google.name
+}
+
+// GetToken returns the current OAuth token (after VerifyCode has been called)
+func (google *GoogleOAuthService) GetToken() *oauth2.Token {
+	return google.token
+}
+
+// RefreshToken is not supported for Google OAuth (no group-based ACLs)
+func (google *GoogleOAuthService) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("token refresh not supported for Google OAuth")
 }

--- a/internal/service/oauth_broker_service.go
+++ b/internal/service/oauth_broker_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 
 	"golang.org/x/exp/slices"
+	"golang.org/x/oauth2"
 )
 
 type OAuthService interface {
@@ -17,6 +18,10 @@ type OAuthService interface {
 	VerifyCode(code string) error
 	Userinfo() (config.Claims, error)
 	GetName() string
+	// GetToken returns the current OAuth token (after VerifyCode has been called)
+	GetToken() *oauth2.Token
+	// RefreshToken uses a refresh token to get a new access/ID token
+	RefreshToken(refreshToken string) (*oauth2.Token, error)
 }
 
 type OAuthBrokerService struct {
@@ -78,4 +83,9 @@ func (broker *OAuthBrokerService) GetUser(service string) (config.Claims, error)
 		return config.Claims{}, errors.New("oauth service not found")
 	}
 	return oauthService.Userinfo()
+}
+
+func (broker *OAuthBrokerService) GetServiceConfig(name string) (config.OAuthServiceConfig, bool) {
+	cfg, exists := broker.configs[name]
+	return cfg, exists
 }

--- a/sql/session_queries.sql
+++ b/sql/session_queries.sql
@@ -10,9 +10,10 @@ INSERT INTO "sessions" (
     "expiry",
     "created_at",
     "oauth_name",
-    "oauth_sub"
+    "oauth_sub",
+    "refresh_token"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 RETURNING *;
 
@@ -34,7 +35,15 @@ UPDATE "sessions" SET
     "oauth_groups" = ?,
     "expiry" = ?,
     "oauth_name" = ?,
-    "oauth_sub" = ?
+    "oauth_sub" = ?,
+    "refresh_token" = ?
+WHERE "uuid" = ?
+RETURNING *;
+
+-- name: UpdateSessionGroups :one
+UPDATE "sessions" SET
+    "oauth_groups" = ?,
+    "refresh_token" = ?
 WHERE "uuid" = ?
 RETURNING *;
 

--- a/sql/session_schemas.sql
+++ b/sql/session_schemas.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS "sessions" (
     "expiry" INTEGER NOT NULL,
     "created_at" INTEGER NOT NULL,
     "oauth_name" TEXT NULL,
-    "oauth_sub" TEXT NULL
+    "oauth_sub" TEXT NULL,
+    "refresh_token" TEXT NULL
 );


### PR DESCRIPTION
Hey, I had this need so I vibe coded this fix. Adding a PR in case it's good enough...

---

## Summary

This PR adds two related fixes for **Microsoft Entra ID** (Azure AD) group-based ACLs:

1. **ID token groups fallback** — Extracts group claims from the ID token when the userinfo endpoint omits them (fixes initial login)
2. **Group refresh on 403** — Uses OAuth refresh tokens to automatically update group membership when a user is added to a group (fixes "must clear cookies" problem)

Fixes #496

---

## Feature 1: ID Token Groups Fallback

### Problem

Microsoft Entra ID returns group memberships in the **ID token** and **access token**, but NOT in the OIDC userinfo endpoint response. Since tinyauth's `GenericOAuthService.Userinfo()` only reads from the userinfo endpoint, `OAuthGroups` is always empty for Microsoft/Azure AD users, and group-based app ACLs always fail.

This was reported in #496 — the reporter confirmed groups were present in the decoded ID token JWT but tinyauth never read them.

### Solution

After the existing userinfo fetch and JSON unmarshal in `Userinfo()`, if `user.Groups` is `nil`, the method now:

1. Retrieves the ID token from the stored OAuth token via `generic.token.Extra("id_token")`
2. Decodes the JWT payload (base64, no signature verification — see note below)
3. Extracts the `"groups"` claim and assigns it to `user.Groups`

This is a pure fallback — if the userinfo endpoint already returns groups (as with other providers like Keycloak, Authentik, etc.), the ID token is never touched.

### Why no signature verification?

The ID token was just received directly from the token endpoint over TLS in the same request flow (inside `VerifyCode()`). The OAuth 2.0 spec considers tokens received this way to be authenticated by the TLS channel itself.

---

## Feature 2: Group Refresh on 403

### Problem

When a user is added to an Entra ID security group, they cannot access the protected resource until they clear their cookies and re-authenticate. This is because group membership is captured once at OAuth login and stored in the session — it's never refreshed until the session expires.

This creates a poor UX where admins add users to groups but users report "it's not working" until someone tells them to clear cookies.

### Solution

When the proxy controller encounters a 403 due to group ACL mismatch, it now:

1. Checks if a refresh token is stored in the session
2. Uses the refresh token to obtain a fresh ID token from the OAuth provider
3. Extracts the updated groups from the new ID token
4. Updates the session with the new groups
5. Retries the group check (max 1 retry to prevent loops)

If the refresh succeeds and the user is now in the required group, they get access immediately. If the refresh fails or groups still don't match, the original 403 is returned.

### Requirements

- The OAuth client must request the `offline_access` scope to receive refresh tokens
- The OAuth provider must support token refresh (Microsoft Entra ID does)
- GitHub and Google OAuth services return "not supported" errors (they don't use groups)

---

## Changes

### Feature 1 (ID token fallback)
- **`internal/service/generic_oauth_service.go`**: Added ID token groups fallback in `Userinfo()` and a `parseIDTokenGroups()` helper

### Feature 2 (Group refresh on 403)
- **`internal/assets/migrations/000007_refresh_token.up.sql`**: New migration to add `refresh_token` column
- **`internal/assets/migrations/000007_refresh_token.down.sql`**: Rollback migration
- **`internal/repository/models.go`**: Added `RefreshToken` field to Session struct
- **`internal/repository/session_queries.sql.go`**: Updated queries to include refresh token, added `UpdateSessionGroups`
- **`sql/session_schemas.sql`**: Updated schema with refresh_token column
- **`sql/session_queries.sql`**: Updated queries
- **`internal/service/oauth_broker_service.go`**: Added `GetToken()` and `RefreshToken()` to OAuthService interface
- **`internal/service/generic_oauth_service.go`**: Implemented `RefreshToken()` and `ExtractGroupsFromToken()`
- **`internal/service/github_oauth_service.go`**: Added stub implementations (returns error)
- **`internal/service/google_oauth_service.go`**: Added stub implementations (returns error)
- **`internal/service/auth_service.go`**: Added `SetOAuthBroker()` and `RefreshOAuthGroups()` methods
- **`internal/controller/oauth_controller.go`**: Store refresh token at login
- **`internal/controller/proxy_controller.go`**: Retry group check after refresh on 403
- **`internal/bootstrap/service_bootstrap.go`**: Wire up OAuth broker to auth service

---

## Testing

Tested with Microsoft Entra ID (single tenant) as the OAuth provider:

**Feature 1 (ID token fallback):**
- Configured "groups" claim in App Registration → Token Configuration → ID tokens
- Configured `TINYAUTH_APPS_<NAME>_OAUTH_GROUPS` with an Entra security group Object ID
- Before: `OAuthGroups` always empty, group ACL always fails (403)
- After: groups extracted from ID token, group ACL works correctly (200)
- No impact on providers that already return groups via userinfo

**Feature 2 (Group refresh on 403):**
- Added `offline_access` to OAuth scopes
- User authenticates and can access resources they're authorized for
- Admin adds user to a new Entra ID security group
- User immediately tries to access the new protected resource
- Before: 403 until cookies cleared
- After: tinyauth refreshes groups via refresh token, user gets access immediately

---

## Configuration

To use the group refresh feature, add `offline_access` to your OAuth scopes:

```yaml
environment:
  - TINYAUTH_OAUTH_GENERIC_SCOPES=openid,profile,email,offline_access
```

The feature is automatic — no other configuration needed. If refresh tokens aren't available, the original 403 behavior is preserved.