### PR TITLE
fix: update healthcheck to use server address and port individually

### DIFF
--- a/cmd/tinyauth/healthcheck.go
+++ b/cmd/tinyauth/healthcheck.go
@@ -28,14 +28,17 @@ func healthcheckCmd() *cli.Command {
 		Run: func(args []string) error {
 			tlog.NewSimpleLogger().Init()
 
-			appUrl := "http://127.0.0.1:3000"
-
 			srvAddr := os.Getenv("TINYAUTH_SERVER_ADDRESS")
-			srvPort := os.Getenv("TINYAUTH_SERVER_PORT")
-
-			if srvAddr != "" && srvPort != "" {
-				appUrl = fmt.Sprintf("http://%s:%s", srvAddr, srvPort)
+			if srvAddr == "" {
+				srvAddr = "127.0.0.1"
 			}
+
+			srvPort := os.Getenv("TINYAUTH_SERVER_PORT")
+			if srvPort == "" {
+				srvPort = "3000"
+			}
+
+			appUrl := fmt.Sprintf("http://%s:%s", srvAddr, srvPort)
 
 			if len(args) > 0 {
 				appUrl = args[0]


### PR DESCRIPTION
# Summary

`healthcheckCmd` does not return healthy when using only the server port variable

# Problem

`TINYAUTH_SERVER_PORT` env variable is only used for creating the appUrl variable to check healthness when in combination with `TINYAUTH_SERVER_ADDRESS`, to have the healthcheck properly working we need to send the two variables

# Solution

Allow to use any of the variables independent of the other, using the default values for both of them as previously was before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check configuration is now environment-driven via TINYAUTH_SERVER_ADDRESS and TINYAUTH_SERVER_PORT variables, with sensible defaults (127.0.0.1 and 3000). Command-line arguments can override these settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->