### PR TITLE
fix: wrong metadata branch used in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: nightly
 
       - name: Generate metadata
         id: metadata


### PR DESCRIPTION
Rather than getting metadata of the tagged version, it was using data from the latest "nightly" tag.

I have not found any more problematic instances like that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the release build process to use the correct release version and tag instead of the nightly branch, ensuring accurate and consistent release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->