### PR TITLE
feat: add lockdown mode on multiple login attempts

### DIFF
--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -242,7 +242,7 @@ func (auth *AuthService) RecordLoginAttempt(identifier string, success bool) {
 	defer auth.loginMutex.Unlock()
 
 	if len(auth.loginAttempts) >= MaxLoginAttemptRecords {
-		if auth.lockdown != nil || !auth.lockdown.Active {
+		if auth.lockdown != nil && auth.lockdown.Active {
 			return
 		}
 		go auth.lockdownMode()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Added a global automatic lockdown that temporarily blocks login attempts when failures spike; locked status reports remaining seconds until re-open.
  * Enforces a hard cap on stored failed-login records and stops recording beyond that limit to limit exposure.

* **Performance**
  * Clears stored login attempt data when lockdown activates and automatically resumes normal operation after the timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->