### PR TITLE
feat: add pkce support to oidc server

### DIFF
--- a/frontend/src/lib/hooks/oidc.ts
+++ b/frontend/src/lib/hooks/oidc.ts
@@ -5,6 +5,8 @@ export type OIDCValues = {
   redirect_uri: string;
   state: string;
   nonce: string;
+  code_challenge: string;
+  code_challenge_method: string;
 };
 
 interface IuseOIDCParams {
@@ -14,7 +16,12 @@ interface IuseOIDCParams {
   missingParams: string[];
 }
 
-const optionalParams: string[] = ["state", "nonce"];
+const optionalParams: string[] = [
+  "state",
+  "nonce",
+  "code_challenge",
+  "code_challenge_method",
+];
 
 export function useOIDCParams(params: URLSearchParams): IuseOIDCParams {
   let compiled: string = "";
@@ -28,6 +35,8 @@ export function useOIDCParams(params: URLSearchParams): IuseOIDCParams {
     redirect_uri: params.get("redirect_uri") ?? "",
     state: params.get("state") ?? "",
     nonce: params.get("nonce") ?? "",
+    code_challenge: params.get("code_challenge") ?? "",
+    code_challenge_method: params.get("code_challenge_method") ?? "",
   };
 
   for (const key of Object.keys(values)) {

--- a/internal/assets/migrations/000007_oidc_pkce.down.sql
+++ b/internal/assets/migrations/000007_oidc_pkce.down.sql
@@ -1,2 +1,1 @@
 ALTER TABLE "oidc_codes" DROP COLUMN "code_challenge";
-ALTER TABLE "oidc_codes" DROP COLUMN "code_challenge_method";

--- a/internal/assets/migrations/000007_oidc_pkce.down.sql
+++ b/internal/assets/migrations/000007_oidc_pkce.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "oidc_codes" DROP COLUMN "code_challenge";
+ALTER TABLE "oidc_codes" DROP COLUMN "code_challenge_method";

--- a/internal/assets/migrations/000007_oidc_pkce.up.sql
+++ b/internal/assets/migrations/000007_oidc_pkce.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "oidc_codes" ADD COLUMN "code_challenge" TEXT DEFAULT "";
+ALTER TABLE "oidc_codes" ADD COLUMN "code_challenge_method" TEXT DEFAULT "";

--- a/internal/assets/migrations/000007_oidc_pkce.up.sql
+++ b/internal/assets/migrations/000007_oidc_pkce.up.sql
@@ -1,2 +1,1 @@
 ALTER TABLE "oidc_codes" ADD COLUMN "code_challenge" TEXT DEFAULT "";
-ALTER TABLE "oidc_codes" ADD COLUMN "code_challenge_method" TEXT DEFAULT "";

--- a/internal/controller/context_controller_test.go
+++ b/internal/controller/context_controller_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/steveiliop56/tinyauth/internal/config"
 	"github.com/steveiliop56/tinyauth/internal/controller"
 	"github.com/steveiliop56/tinyauth/internal/utils"
+	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContextController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	controllerConfig := controller.ContextControllerConfig{
 		Providers: []controller.Provider{
 			{

--- a/internal/controller/health_controller_test.go
+++ b/internal/controller/health_controller_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/steveiliop56/tinyauth/internal/controller"
+	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tests := []struct {
 		description string
 		path        string

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -309,7 +309,6 @@ func (controller *OIDCController) Token(c *gin.Context) {
 			return
 		}
 
-		tlog.App.Debug().Str("challenge", entry.CodeChallenge).Str("verifier", req.CodeVerifier).Msg("Validating PKCE")
 		ok := controller.oidc.ValidatePKCE(entry.CodeChallenge, req.CodeVerifier)
 
 		if !ok {

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -309,7 +309,8 @@ func (controller *OIDCController) Token(c *gin.Context) {
 			return
 		}
 
-		ok := controller.oidc.ValidatePKCE(entry.CodeChallenge, entry.CodeChallengeMethod, req.CodeVerifier)
+		tlog.App.Debug().Str("challenge", entry.CodeChallenge).Str("verifier", req.CodeVerifier).Msg("Validating PKCE")
+		ok := controller.oidc.ValidatePKCE(entry.CodeChallenge, req.CodeVerifier)
 
 		if !ok {
 			tlog.App.Warn().Msg("PKCE validation failed")

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -34,6 +34,7 @@ type TokenRequest struct {
 	RefreshToken string `form:"refresh_token" url:"refresh_token"`
 	ClientSecret string `form:"client_secret" url:"client_secret"`
 	ClientID     string `form:"client_id" url:"client_id"`
+	CodeVerifier string `form:"code_verifier" url:"code_verifier"`
 }
 
 type CallbackError struct {
@@ -302,6 +303,16 @@ func (controller *OIDCController) Token(c *gin.Context) {
 
 		if entry.RedirectURI != req.RedirectURI {
 			tlog.App.Warn().Str("redirect_uri", req.RedirectURI).Msg("Redirect URI mismatch")
+			c.JSON(400, gin.H{
+				"error": "invalid_grant",
+			})
+			return
+		}
+
+		ok := controller.oidc.ValidatePKCE(entry.CodeChallenge, entry.CodeChallengeMethod, req.CodeVerifier)
+
+		if !ok {
+			tlog.App.Warn().Msg("PKCE validation failed")
 			c.JSON(400, gin.H{
 				"error": "invalid_grant",
 			})

--- a/internal/controller/oidc_controller_test.go
+++ b/internal/controller/oidc_controller_test.go
@@ -652,8 +652,8 @@ func TestOIDCController(t *testing.T) {
 				assert.NoError(t, err)
 
 				queryParams := url.Query()
-				code := queryParams.Get("error")
-				assert.NotEmpty(t, code)
+				error := queryParams.Get("error")
+				assert.NotEmpty(t, error)
 			},
 		},
 	}

--- a/internal/controller/oidc_controller_test.go
+++ b/internal/controller/oidc_controller_test.go
@@ -615,6 +615,47 @@ func TestOIDCController(t *testing.T) {
 				assert.Equal(t, 400, recorder.Code)
 			},
 		},
+		{
+			description: "Ensure request with invalid challenge method fails",
+			middlewares: []gin.HandlerFunc{
+				simpleCtx,
+			},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				hasher := sha256.New()
+				hasher.Write([]byte("some-challenge"))
+				codeChallenge := hasher.Sum(nil)
+				codeChallengeEncoded := base64.RawURLEncoding.EncodeToString(codeChallenge)
+				reqBody := service.AuthorizeRequest{
+					Scope:               "openid",
+					ResponseType:        "code",
+					ClientID:            "some-client-id",
+					RedirectURI:         "https://test.example.com/callback",
+					State:               "some-state",
+					Nonce:               "some-nonce",
+					CodeChallenge:       codeChallengeEncoded,
+					CodeChallengeMethod: "foo",
+				}
+				reqBodyBytes, err := json.Marshal(reqBody)
+				assert.NoError(t, err)
+
+				req := httptest.NewRequest("POST", "/api/oidc/authorize", strings.NewReader(string(reqBodyBytes)))
+				req.Header.Set("Content-Type", "application/json")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, 200, recorder.Code)
+
+				var res map[string]any
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				assert.NoError(t, err)
+
+				redirectURI := res["redirect_uri"].(string)
+				url, err := url.Parse(redirectURI)
+				assert.NoError(t, err)
+
+				queryParams := url.Query()
+				code := queryParams.Get("error")
+				assert.NotEmpty(t, code)
+			},
+		},
 	}
 
 	app := bootstrap.NewBootstrapApp(config.Config{})

--- a/internal/controller/oidc_controller_test.go
+++ b/internal/controller/oidc_controller_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/steveiliop56/tinyauth/internal/controller"
 	"github.com/steveiliop56/tinyauth/internal/repository"
 	"github.com/steveiliop56/tinyauth/internal/service"
+	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOIDCController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tempDir := t.TempDir()
 
 	oidcServiceCfg := service.OIDCServiceConfig{
@@ -473,6 +475,7 @@ func TestOIDCController(t *testing.T) {
 				assert.NotEmpty(t, code)
 
 				// Now exchange the code for a token
+				recorder = httptest.NewRecorder()
 				tokenReqBody := controller.TokenRequest{
 					GrantType:    "authorization_code",
 					Code:         code,
@@ -499,7 +502,7 @@ func TestOIDCController(t *testing.T) {
 				hasher := sha256.New()
 				hasher.Write([]byte("some-challenge"))
 				codeChallenge := hasher.Sum(nil)
-				codeChallengeEncoded := base64.URLEncoding.EncodeToString(codeChallenge)
+				codeChallengeEncoded := base64.RawURLEncoding.EncodeToString(codeChallenge)
 				reqBody := service.AuthorizeRequest{
 					Scope:               "openid",
 					ResponseType:        "code",
@@ -533,6 +536,7 @@ func TestOIDCController(t *testing.T) {
 				assert.NotEmpty(t, code)
 
 				// Now exchange the code for a token
+				recorder = httptest.NewRecorder()
 				tokenReqBody := controller.TokenRequest{
 					GrantType:    "authorization_code",
 					Code:         code,
@@ -559,7 +563,7 @@ func TestOIDCController(t *testing.T) {
 				hasher := sha256.New()
 				hasher.Write([]byte("some-challenge"))
 				codeChallenge := hasher.Sum(nil)
-				codeChallengeEncoded := base64.URLEncoding.EncodeToString(codeChallenge)
+				codeChallengeEncoded := base64.RawURLEncoding.EncodeToString(codeChallenge)
 				reqBody := service.AuthorizeRequest{
 					Scope:               "openid",
 					ResponseType:        "code",
@@ -593,6 +597,7 @@ func TestOIDCController(t *testing.T) {
 				assert.NotEmpty(t, code)
 
 				// Now exchange the code for a token
+				recorder = httptest.NewRecorder()
 				tokenReqBody := controller.TokenRequest{
 					GrantType:    "authorization_code",
 					Code:         code,
@@ -607,7 +612,7 @@ func TestOIDCController(t *testing.T) {
 				req.SetBasicAuth("some-client-id", "some-client-secret")
 				router.ServeHTTP(recorder, req)
 
-				assert.Equal(t, 200, recorder.Code)
+				assert.Equal(t, 400, recorder.Code)
 			},
 		},
 	}

--- a/internal/controller/oidc_controller_test.go
+++ b/internal/controller/oidc_controller_test.go
@@ -1,6 +1,8 @@
 package controller_test
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"net/http/httptest"
 	"net/url"
@@ -429,6 +431,183 @@ func TestOIDCController(t *testing.T) {
 				// We should not have an email claim since we didn't request it in the scope
 				_, ok = userInfoRes["email"]
 				assert.False(t, ok, "Did not expect email claim in userinfo response")
+			},
+		},
+		{
+			description: "Ensure plain PKCE succeeds",
+			middlewares: []gin.HandlerFunc{
+				simpleCtx,
+			},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				reqBody := service.AuthorizeRequest{
+					Scope:         "openid",
+					ResponseType:  "code",
+					ClientID:      "some-client-id",
+					RedirectURI:   "https://test.example.com/callback",
+					State:         "some-state",
+					Nonce:         "some-nonce",
+					CodeChallenge: "some-challenge",
+					// Not setting a code challenge method should default to "plain"
+					CodeChallengeMethod: "",
+				}
+				reqBodyBytes, err := json.Marshal(reqBody)
+				assert.NoError(t, err)
+
+				req := httptest.NewRequest("POST", "/api/oidc/authorize", strings.NewReader(string(reqBodyBytes)))
+				req.Header.Set("Content-Type", "application/json")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, 200, recorder.Code)
+
+				var res map[string]any
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				assert.NoError(t, err)
+
+				redirectURI := res["redirect_uri"].(string)
+				url, err := url.Parse(redirectURI)
+				assert.NoError(t, err)
+
+				queryParams := url.Query()
+				assert.Equal(t, queryParams.Get("state"), "some-state")
+
+				code := queryParams.Get("code")
+				assert.NotEmpty(t, code)
+
+				// Now exchange the code for a token
+				tokenReqBody := controller.TokenRequest{
+					GrantType:    "authorization_code",
+					Code:         code,
+					RedirectURI:  "https://test.example.com/callback",
+					CodeVerifier: "some-challenge",
+				}
+				reqBodyEncoded, err := query.Values(tokenReqBody)
+				assert.NoError(t, err)
+
+				req = httptest.NewRequest("POST", "/api/oidc/token", strings.NewReader(reqBodyEncoded.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.SetBasicAuth("some-client-id", "some-client-secret")
+				router.ServeHTTP(recorder, req)
+
+				assert.Equal(t, 200, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure S256 PKCE succeeds",
+			middlewares: []gin.HandlerFunc{
+				simpleCtx,
+			},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				hasher := sha256.New()
+				hasher.Write([]byte("some-challenge"))
+				codeChallenge := hasher.Sum(nil)
+				codeChallengeEncoded := base64.URLEncoding.EncodeToString(codeChallenge)
+				reqBody := service.AuthorizeRequest{
+					Scope:               "openid",
+					ResponseType:        "code",
+					ClientID:            "some-client-id",
+					RedirectURI:         "https://test.example.com/callback",
+					State:               "some-state",
+					Nonce:               "some-nonce",
+					CodeChallenge:       codeChallengeEncoded,
+					CodeChallengeMethod: "S256",
+				}
+				reqBodyBytes, err := json.Marshal(reqBody)
+				assert.NoError(t, err)
+
+				req := httptest.NewRequest("POST", "/api/oidc/authorize", strings.NewReader(string(reqBodyBytes)))
+				req.Header.Set("Content-Type", "application/json")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, 200, recorder.Code)
+
+				var res map[string]any
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				assert.NoError(t, err)
+
+				redirectURI := res["redirect_uri"].(string)
+				url, err := url.Parse(redirectURI)
+				assert.NoError(t, err)
+
+				queryParams := url.Query()
+				assert.Equal(t, queryParams.Get("state"), "some-state")
+
+				code := queryParams.Get("code")
+				assert.NotEmpty(t, code)
+
+				// Now exchange the code for a token
+				tokenReqBody := controller.TokenRequest{
+					GrantType:    "authorization_code",
+					Code:         code,
+					RedirectURI:  "https://test.example.com/callback",
+					CodeVerifier: "some-challenge",
+				}
+				reqBodyEncoded, err := query.Values(tokenReqBody)
+				assert.NoError(t, err)
+
+				req = httptest.NewRequest("POST", "/api/oidc/token", strings.NewReader(reqBodyEncoded.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.SetBasicAuth("some-client-id", "some-client-secret")
+				router.ServeHTTP(recorder, req)
+
+				assert.Equal(t, 200, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure request with invalid PKCE fails",
+			middlewares: []gin.HandlerFunc{
+				simpleCtx,
+			},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				hasher := sha256.New()
+				hasher.Write([]byte("some-challenge"))
+				codeChallenge := hasher.Sum(nil)
+				codeChallengeEncoded := base64.URLEncoding.EncodeToString(codeChallenge)
+				reqBody := service.AuthorizeRequest{
+					Scope:               "openid",
+					ResponseType:        "code",
+					ClientID:            "some-client-id",
+					RedirectURI:         "https://test.example.com/callback",
+					State:               "some-state",
+					Nonce:               "some-nonce",
+					CodeChallenge:       codeChallengeEncoded,
+					CodeChallengeMethod: "S256",
+				}
+				reqBodyBytes, err := json.Marshal(reqBody)
+				assert.NoError(t, err)
+
+				req := httptest.NewRequest("POST", "/api/oidc/authorize", strings.NewReader(string(reqBodyBytes)))
+				req.Header.Set("Content-Type", "application/json")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, 200, recorder.Code)
+
+				var res map[string]any
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				assert.NoError(t, err)
+
+				redirectURI := res["redirect_uri"].(string)
+				url, err := url.Parse(redirectURI)
+				assert.NoError(t, err)
+
+				queryParams := url.Query()
+				assert.Equal(t, queryParams.Get("state"), "some-state")
+
+				code := queryParams.Get("code")
+				assert.NotEmpty(t, code)
+
+				// Now exchange the code for a token
+				tokenReqBody := controller.TokenRequest{
+					GrantType:    "authorization_code",
+					Code:         code,
+					RedirectURI:  "https://test.example.com/callback",
+					CodeVerifier: "some-challenge-1",
+				}
+				reqBodyEncoded, err := query.Values(tokenReqBody)
+				assert.NoError(t, err)
+
+				req = httptest.NewRequest("POST", "/api/oidc/token", strings.NewReader(reqBodyEncoded.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.SetBasicAuth("some-client-id", "some-client-secret")
+				router.ServeHTTP(recorder, req)
+
+				assert.Equal(t, 200, recorder.Code)
 			},
 		},
 	}

--- a/internal/controller/proxy_controller_test.go
+++ b/internal/controller/proxy_controller_test.go
@@ -391,8 +391,6 @@ func TestProxyController(t *testing.T) {
 		},
 	}
 
-	tlog.NewSimpleLogger().Init()
-
 	oauthBrokerCfgs := make(map[string]config.OAuthServiceConfig)
 
 	app := bootstrap.NewBootstrapApp(config.Config{})

--- a/internal/controller/proxy_controller_test.go
+++ b/internal/controller/proxy_controller_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestProxyController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tempDir := t.TempDir()
 
 	authServiceCfg := service.AuthServiceConfig{

--- a/internal/controller/resources_controller_test.go
+++ b/internal/controller/resources_controller_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/steveiliop56/tinyauth/internal/controller"
+	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestResourcesController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tempDir := t.TempDir()
 
 	resourcesControllerCfg := controller.ResourcesControllerConfig{

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestUserController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tempDir := t.TempDir()
 
 	authServiceCfg := service.AuthServiceConfig{

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -275,8 +275,6 @@ func TestUserController(t *testing.T) {
 		},
 	}
 
-	tlog.NewSimpleLogger().Init()
-
 	oauthBrokerCfgs := make(map[string]config.OAuthServiceConfig)
 
 	app := bootstrap.NewBootstrapApp(config.Config{})

--- a/internal/controller/well_known_controller_test.go
+++ b/internal/controller/well_known_controller_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/steveiliop56/tinyauth/internal/controller"
 	"github.com/steveiliop56/tinyauth/internal/repository"
 	"github.com/steveiliop56/tinyauth/internal/service"
+	"github.com/steveiliop56/tinyauth/internal/utils/tlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWellKnownController(t *testing.T) {
+	tlog.NewTestLogger().Init()
 	tempDir := t.TempDir()
 
 	oidcServiceCfg := service.OIDCServiceConfig{

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -5,13 +5,15 @@
 package repository
 
 type OidcCode struct {
-	Sub         string
-	CodeHash    string
-	Scope       string
-	RedirectURI string
-	ClientID    string
-	ExpiresAt   int64
-	Nonce       string
+	Sub                 string
+	CodeHash            string
+	Scope               string
+	RedirectURI         string
+	ClientID            string
+	ExpiresAt           int64
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
 }
 
 type OidcToken struct {

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -5,15 +5,14 @@
 package repository
 
 type OidcCode struct {
-	Sub                 string
-	CodeHash            string
-	Scope               string
-	RedirectURI         string
-	ClientID            string
-	ExpiresAt           int64
-	Nonce               string
-	CodeChallenge       string
-	CodeChallengeMethod string
+	Sub           string
+	CodeHash      string
+	Scope         string
+	RedirectURI   string
+	ClientID      string
+	ExpiresAt     int64
+	Nonce         string
+	CodeChallenge string
 }
 
 type OidcToken struct {

--- a/internal/repository/oidc_queries.sql.go
+++ b/internal/repository/oidc_queries.sql.go
@@ -17,21 +17,25 @@ INSERT INTO "oidc_codes" (
     "redirect_uri",
     "client_id",
     "expires_at",
-    "nonce"
+    "nonce",
+    "code_challenge",
+    "code_challenge_method"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
 `
 
 type CreateOidcCodeParams struct {
-	Sub         string
-	CodeHash    string
-	Scope       string
-	RedirectURI string
-	ClientID    string
-	ExpiresAt   int64
-	Nonce       string
+	Sub                 string
+	CodeHash            string
+	Scope               string
+	RedirectURI         string
+	ClientID            string
+	ExpiresAt           int64
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
 }
 
 func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) (OidcCode, error) {
@@ -43,6 +47,8 @@ func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) 
 		arg.ClientID,
 		arg.ExpiresAt,
 		arg.Nonce,
+		arg.CodeChallenge,
+		arg.CodeChallengeMethod,
 	)
 	var i OidcCode
 	err := row.Scan(
@@ -53,6 +59,8 @@ func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) 
 		&i.ClientID,
 		&i.ExpiresAt,
 		&i.Nonce,
+		&i.CodeChallenge,
+		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
@@ -156,7 +164,7 @@ func (q *Queries) CreateOidcUserInfo(ctx context.Context, arg CreateOidcUserInfo
 const deleteExpiredOidcCodes = `-- name: DeleteExpiredOidcCodes :many
 DELETE FROM "oidc_codes"
 WHERE "expires_at" < ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
 `
 
 func (q *Queries) DeleteExpiredOidcCodes(ctx context.Context, expiresAt int64) ([]OidcCode, error) {
@@ -176,6 +184,8 @@ func (q *Queries) DeleteExpiredOidcCodes(ctx context.Context, expiresAt int64) (
 			&i.ClientID,
 			&i.ExpiresAt,
 			&i.Nonce,
+			&i.CodeChallenge,
+			&i.CodeChallengeMethod,
 		); err != nil {
 			return nil, err
 		}
@@ -286,7 +296,7 @@ func (q *Queries) DeleteOidcUserInfo(ctx context.Context, sub string) error {
 const getOidcCode = `-- name: GetOidcCode :one
 DELETE FROM "oidc_codes"
 WHERE "code_hash" = ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
 `
 
 func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, error) {
@@ -300,6 +310,8 @@ func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, e
 		&i.ClientID,
 		&i.ExpiresAt,
 		&i.Nonce,
+		&i.CodeChallenge,
+		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
@@ -307,7 +319,7 @@ func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, e
 const getOidcCodeBySub = `-- name: GetOidcCodeBySub :one
 DELETE FROM "oidc_codes"
 WHERE "sub" = ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
 `
 
 func (q *Queries) GetOidcCodeBySub(ctx context.Context, sub string) (OidcCode, error) {
@@ -321,12 +333,14 @@ func (q *Queries) GetOidcCodeBySub(ctx context.Context, sub string) (OidcCode, e
 		&i.ClientID,
 		&i.ExpiresAt,
 		&i.Nonce,
+		&i.CodeChallenge,
+		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
 
 const getOidcCodeBySubUnsafe = `-- name: GetOidcCodeBySubUnsafe :one
-SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce FROM "oidc_codes"
+SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method FROM "oidc_codes"
 WHERE "sub" = ?
 `
 
@@ -341,12 +355,14 @@ func (q *Queries) GetOidcCodeBySubUnsafe(ctx context.Context, sub string) (OidcC
 		&i.ClientID,
 		&i.ExpiresAt,
 		&i.Nonce,
+		&i.CodeChallenge,
+		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
 
 const getOidcCodeUnsafe = `-- name: GetOidcCodeUnsafe :one
-SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce FROM "oidc_codes"
+SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method FROM "oidc_codes"
 WHERE "code_hash" = ?
 `
 
@@ -361,6 +377,8 @@ func (q *Queries) GetOidcCodeUnsafe(ctx context.Context, codeHash string) (OidcC
 		&i.ClientID,
 		&i.ExpiresAt,
 		&i.Nonce,
+		&i.CodeChallenge,
+		&i.CodeChallengeMethod,
 	)
 	return i, err
 }

--- a/internal/repository/oidc_queries.sql.go
+++ b/internal/repository/oidc_queries.sql.go
@@ -18,24 +18,22 @@ INSERT INTO "oidc_codes" (
     "client_id",
     "expires_at",
     "nonce",
-    "code_challenge",
-    "code_challenge_method"
+    "code_challenge"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?
 )
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge
 `
 
 type CreateOidcCodeParams struct {
-	Sub                 string
-	CodeHash            string
-	Scope               string
-	RedirectURI         string
-	ClientID            string
-	ExpiresAt           int64
-	Nonce               string
-	CodeChallenge       string
-	CodeChallengeMethod string
+	Sub           string
+	CodeHash      string
+	Scope         string
+	RedirectURI   string
+	ClientID      string
+	ExpiresAt     int64
+	Nonce         string
+	CodeChallenge string
 }
 
 func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) (OidcCode, error) {
@@ -48,7 +46,6 @@ func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) 
 		arg.ExpiresAt,
 		arg.Nonce,
 		arg.CodeChallenge,
-		arg.CodeChallengeMethod,
 	)
 	var i OidcCode
 	err := row.Scan(
@@ -60,7 +57,6 @@ func (q *Queries) CreateOidcCode(ctx context.Context, arg CreateOidcCodeParams) 
 		&i.ExpiresAt,
 		&i.Nonce,
 		&i.CodeChallenge,
-		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
@@ -164,7 +160,7 @@ func (q *Queries) CreateOidcUserInfo(ctx context.Context, arg CreateOidcUserInfo
 const deleteExpiredOidcCodes = `-- name: DeleteExpiredOidcCodes :many
 DELETE FROM "oidc_codes"
 WHERE "expires_at" < ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge
 `
 
 func (q *Queries) DeleteExpiredOidcCodes(ctx context.Context, expiresAt int64) ([]OidcCode, error) {
@@ -185,7 +181,6 @@ func (q *Queries) DeleteExpiredOidcCodes(ctx context.Context, expiresAt int64) (
 			&i.ExpiresAt,
 			&i.Nonce,
 			&i.CodeChallenge,
-			&i.CodeChallengeMethod,
 		); err != nil {
 			return nil, err
 		}
@@ -296,7 +291,7 @@ func (q *Queries) DeleteOidcUserInfo(ctx context.Context, sub string) error {
 const getOidcCode = `-- name: GetOidcCode :one
 DELETE FROM "oidc_codes"
 WHERE "code_hash" = ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge
 `
 
 func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, error) {
@@ -311,7 +306,6 @@ func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, e
 		&i.ExpiresAt,
 		&i.Nonce,
 		&i.CodeChallenge,
-		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
@@ -319,7 +313,7 @@ func (q *Queries) GetOidcCode(ctx context.Context, codeHash string) (OidcCode, e
 const getOidcCodeBySub = `-- name: GetOidcCodeBySub :one
 DELETE FROM "oidc_codes"
 WHERE "sub" = ?
-RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method
+RETURNING sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge
 `
 
 func (q *Queries) GetOidcCodeBySub(ctx context.Context, sub string) (OidcCode, error) {
@@ -334,13 +328,12 @@ func (q *Queries) GetOidcCodeBySub(ctx context.Context, sub string) (OidcCode, e
 		&i.ExpiresAt,
 		&i.Nonce,
 		&i.CodeChallenge,
-		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
 
 const getOidcCodeBySubUnsafe = `-- name: GetOidcCodeBySubUnsafe :one
-SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method FROM "oidc_codes"
+SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge FROM "oidc_codes"
 WHERE "sub" = ?
 `
 
@@ -356,13 +349,12 @@ func (q *Queries) GetOidcCodeBySubUnsafe(ctx context.Context, sub string) (OidcC
 		&i.ExpiresAt,
 		&i.Nonce,
 		&i.CodeChallenge,
-		&i.CodeChallengeMethod,
 	)
 	return i, err
 }
 
 const getOidcCodeUnsafe = `-- name: GetOidcCodeUnsafe :one
-SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge, code_challenge_method FROM "oidc_codes"
+SELECT sub, code_hash, scope, redirect_uri, client_id, expires_at, nonce, code_challenge FROM "oidc_codes"
 WHERE "code_hash" = ?
 `
 
@@ -378,7 +370,6 @@ func (q *Queries) GetOidcCodeUnsafe(ctx context.Context, codeHash string) (OidcC
 		&i.ExpiresAt,
 		&i.Nonce,
 		&i.CodeChallenge,
-		&i.CodeChallengeMethod,
 	)
 	return i, err
 }

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -75,12 +75,14 @@ type TokenResponse struct {
 }
 
 type AuthorizeRequest struct {
-	Scope        string `json:"scope" binding:"required"`
-	ResponseType string `json:"response_type" binding:"required"`
-	ClientID     string `json:"client_id" binding:"required"`
-	RedirectURI  string `json:"redirect_uri" binding:"required"`
-	State        string `json:"state"`
-	Nonce        string `json:"nonce"`
+	Scope               string `json:"scope" binding:"required"`
+	ResponseType        string `json:"response_type" binding:"required"`
+	ClientID            string `json:"client_id" binding:"required"`
+	RedirectURI         string `json:"redirect_uri" binding:"required"`
+	State               string `json:"state"`
+	Nonce               string `json:"nonce"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
 }
 
 type OIDCServiceConfig struct {
@@ -293,6 +295,13 @@ func (service *OIDCService) ValidateAuthorizeParams(req AuthorizeRequest) error 
 		return errors.New("invalid_request_uri")
 	}
 
+	// PKCE code challenge method if set
+	if req.CodeChallenge != "" && req.CodeChallengeMethod != "" {
+		if req.CodeChallengeMethod != "S256" || req.CodeChallenge == "plain" {
+			return errors.New("invalid_request")
+		}
+	}
+
 	return nil
 }
 
@@ -306,8 +315,7 @@ func (service *OIDCService) StoreCode(c *gin.Context, sub string, code string, r
 	// Fixed 10 minutes
 	expiresAt := time.Now().Add(time.Minute * time.Duration(10)).Unix()
 
-	// Insert the code into the database
-	_, err := service.queries.CreateOidcCode(c, repository.CreateOidcCodeParams{
+	entry := repository.CreateOidcCodeParams{
 		Sub:      sub,
 		CodeHash: service.Hash(code),
 		// Here it's safe to split and trust the output since, we validated the scopes before
@@ -316,7 +324,21 @@ func (service *OIDCService) StoreCode(c *gin.Context, sub string, code string, r
 		ClientID:    req.ClientID,
 		ExpiresAt:   expiresAt,
 		Nonce:       req.Nonce,
-	})
+	}
+
+	if req.CodeChallenge != "" {
+		if req.CodeChallengeMethod == "S256" {
+			entry.CodeChallenge = req.CodeChallenge
+			entry.CodeChallengeMethod = "S256"
+		} else {
+			entry.CodeChallenge = service.hashAndEncodePKCE(req.CodeChallenge)
+			entry.CodeChallengeMethod = "plain"
+			tlog.App.Warn().Msg("Received plain PKCE code challenge, it's recommended to use S256 for better security")
+		}
+	}
+
+	// Insert the code into the database
+	_, err := service.queries.CreateOidcCode(c, entry)
 
 	return err
 }
@@ -727,4 +749,21 @@ func (service *OIDCService) GetJWK() ([]byte, error) {
 	}
 
 	return jwk.Public().MarshalJSON()
+}
+
+func (service *OIDCService) ValidatePKCE(codeChallenge string, codeChallengeMethod string, codeVerifier string) bool {
+	if codeChallenge == "" {
+		return true
+	}
+	if codeChallengeMethod == "plain" {
+		// Code challenge is hashed and encoded in the database for security reasons
+		return codeChallenge == service.hashAndEncodePKCE(codeVerifier)
+	}
+	return codeChallenge == codeVerifier
+}
+
+func (service *OIDCService) hashAndEncodePKCE(codeVerifier string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(codeVerifier))
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 }

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -297,7 +297,7 @@ func (service *OIDCService) ValidateAuthorizeParams(req AuthorizeRequest) error 
 
 	// PKCE code challenge method if set
 	if req.CodeChallenge != "" && req.CodeChallengeMethod != "" {
-		if req.CodeChallengeMethod != "S256" || req.CodeChallenge == "plain" {
+		if req.CodeChallengeMethod != "S256" && req.CodeChallengeMethod != "plain" {
 			return errors.New("invalid_request")
 		}
 	}
@@ -329,10 +329,8 @@ func (service *OIDCService) StoreCode(c *gin.Context, sub string, code string, r
 	if req.CodeChallenge != "" {
 		if req.CodeChallengeMethod == "S256" {
 			entry.CodeChallenge = req.CodeChallenge
-			entry.CodeChallengeMethod = "S256"
 		} else {
 			entry.CodeChallenge = service.hashAndEncodePKCE(req.CodeChallenge)
-			entry.CodeChallengeMethod = "plain"
 			tlog.App.Warn().Msg("Received plain PKCE code challenge, it's recommended to use S256 for better security")
 		}
 	}
@@ -751,19 +749,15 @@ func (service *OIDCService) GetJWK() ([]byte, error) {
 	return jwk.Public().MarshalJSON()
 }
 
-func (service *OIDCService) ValidatePKCE(codeChallenge string, codeChallengeMethod string, codeVerifier string) bool {
+func (service *OIDCService) ValidatePKCE(codeChallenge string, codeVerifier string) bool {
 	if codeChallenge == "" {
 		return true
 	}
-	if codeChallengeMethod == "plain" {
-		// Code challenge is hashed and encoded in the database for security reasons
-		return codeChallenge == service.hashAndEncodePKCE(codeVerifier)
-	}
-	return codeChallenge == codeVerifier
+	return codeChallenge == service.hashAndEncodePKCE(codeVerifier)
 }
 
 func (service *OIDCService) hashAndEncodePKCE(codeVerifier string) string {
 	hasher := sha256.New()
 	hasher.Write([]byte(codeVerifier))
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	return base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
 }

--- a/internal/utils/tlog/log_wrapper.go
+++ b/internal/utils/tlog/log_wrapper.go
@@ -55,6 +55,17 @@ func NewSimpleLogger() *Logger {
 	})
 }
 
+func NewTestLogger() *Logger {
+	return NewLogger(config.LogConfig{
+		Level: "trace",
+		Streams: config.LogStreams{
+			HTTP:  config.LogStreamConfig{Enabled: true},
+			App:   config.LogStreamConfig{Enabled: true},
+			Audit: config.LogStreamConfig{Enabled: true},
+		},
+	})
+}
+
 func (l *Logger) Init() {
 	Audit = l.Audit
 	HTTP = l.HTTP

--- a/sql/oidc_queries.sql
+++ b/sql/oidc_queries.sql
@@ -7,10 +7,9 @@ INSERT INTO "oidc_codes" (
     "client_id",
     "expires_at",
     "nonce",
-    "code_challenge",
-    "code_challenge_method"
+    "code_challenge"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?
 )
 RETURNING *;
 

--- a/sql/oidc_queries.sql
+++ b/sql/oidc_queries.sql
@@ -6,9 +6,11 @@ INSERT INTO "oidc_codes" (
     "redirect_uri",
     "client_id",
     "expires_at",
-    "nonce"
+    "nonce",
+    "code_challenge",
+    "code_challenge_method"
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 RETURNING *;
 

--- a/sql/oidc_schemas.sql
+++ b/sql/oidc_schemas.sql
@@ -6,8 +6,7 @@ CREATE TABLE IF NOT EXISTS "oidc_codes" (
     "client_id" TEXT NOT NULL,
     "expires_at" INTEGER NOT NULL,
     "nonce" TEXT DEFAULT "",
-    "code_challenge" TEXT DEFAULT "",
-    "code_challenge_method" TEXT DEFAULT ""
+    "code_challenge" TEXT DEFAULT ""
 );
 
 CREATE TABLE IF NOT EXISTS "oidc_tokens" (

--- a/sql/oidc_schemas.sql
+++ b/sql/oidc_schemas.sql
@@ -5,7 +5,9 @@ CREATE TABLE IF NOT EXISTS "oidc_codes" (
     "redirect_uri" TEXT NOT NULL,
     "client_id" TEXT NOT NULL,
     "expires_at" INTEGER NOT NULL,
-    "nonce" TEXT DEFAULT ""
+    "nonce" TEXT DEFAULT "",
+    "code_challenge" TEXT DEFAULT "",
+    "code_challenge_method" TEXT DEFAULT ""
 );
 
 CREATE TABLE IF NOT EXISTS "oidc_tokens" (

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -26,3 +26,7 @@ sql:
             go_type: "string"
           - column: "oidc_tokens.nonce"
             go_type: "string"
+          - column: "oidc_codes.code_challenge"
+            go_type: "string"
+          - column: "oidc_codes.code_challenge_method"
+            go_type: "string"

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -28,5 +28,3 @@ sql:
             go_type: "string"
           - column: "oidc_codes.code_challenge"
             go_type: "string"
-          - column: "oidc_codes.code_challenge_method"
-            go_type: "string"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PKCE support for OIDC flows (plain and S256); PKCE parameters are now accepted and propagated.
* **Bug Fixes**
  * Token exchanges validate PKCE and reject invalid verifiers (returns invalid_grant).
* **Database**
  * Schema updated to persist PKCE challenges for authorization codes.
* **Tests**
  * Expanded end-to-end tests covering plain, S256, invalid challenges, and error cases.
* **Chores**
  * Tests use an improved test logger initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->