### PR TITLE
feat(oidc): add post route for /userinfo

### DIFF
--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -70,6 +70,7 @@ func (controller *OIDCController) SetupRoutes() {
 	oidcGroup.POST("/authorize", controller.Authorize)
 	oidcGroup.POST("/token", controller.Token)
 	oidcGroup.GET("/userinfo", controller.Userinfo)
+	oidcGroup.POST("/userinfo", controller.Userinfo)
 }
 
 func (controller *OIDCController) GetClientInfo(c *gin.Context) {

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -24,6 +24,7 @@ var (
 		"GET /api/oidc/clients",
 		"POST /api/oidc/token",
 		"GET /api/oidc/userinfo",
+		"POST /api/oidc/userinfo",
 		"GET /resources",
 		"POST /api/user/login",
 		"GET /.well-known/openid-configuration",


### PR DESCRIPTION
easy one-liner to pass `oidcc-userinfo-post-header` test in conformance suite.

Before:

<img width="1663" height="355" alt="image" src="https://github.com/user-attachments/assets/aebd4966-0a28-439e-8d1d-8c4a0a6ce159" />


After:

<img width="1663" height="355" alt="image" src="https://github.com/user-attachments/assets/2ed53f7d-53fc-42e4-aa3d-3a7dd791b3b6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The OIDC userinfo endpoint now accepts POST requests in addition to GET, improving compatibility with clients that use POST.
  * POST-based userinfo requests will be handled without enforcing the usual session/basic-auth middleware, ensuring smoother exchange for supported client workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->