### PR TITLE
fix: preserve OIDC params during login → TOTP redirect

### DIFF
--- a/frontend/src/lib/hooks/oidc.ts
+++ b/frontend/src/lib/hooks/oidc.ts
@@ -38,14 +38,14 @@ function decodeRequestObject(jwt: string): Record<string, string> {
   }
 }
 
-export const useOIDCParams = (
-  params: URLSearchParams,
-): {
+export type OIDCParamsResult = {
   values: z.infer<typeof oidcParamsSchema>;
   issues: string[];
   isOidc: boolean;
   compiled: string;
-} => {
+};
+
+export const parseOIDCParams = (params: URLSearchParams): OIDCParamsResult => {
   const obj = Object.fromEntries(params.entries());
 
   // RFC 9101 / OIDC Core 6.1: if `request` param present, decode JWT payload
@@ -73,4 +73,8 @@ export const useOIDCParams = (
     isOidc: false,
     compiled: "",
   };
+};
+
+export const useOIDCParams = (params: URLSearchParams): OIDCParamsResult => {
+  return parseOIDCParams(params);
 };

--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -18,7 +18,7 @@ import { OAuthButton } from "@/components/ui/oauth-button";
 import { SeperatorWithChildren } from "@/components/ui/separator";
 import { useAppContext } from "@/context/app-context";
 import { useUserContext } from "@/context/user-context";
-import { useOIDCParams } from "@/lib/hooks/oidc";
+import { useOIDCParams, parseOIDCParams } from "@/lib/hooks/oidc";
 import { LoginSchema } from "@/schemas/login-schema";
 import { useMutation } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
@@ -113,13 +113,23 @@ export const LoginPage = () => {
     mutationFn: (values: LoginSchema) => axios.post("/api/user/login", values),
     mutationKey: ["login"],
     onSuccess: (data) => {
+      // Re-parse OIDC params from window.location.search to avoid stale
+      // closures. When the authorize page redirects to /login via React
+      // Router's <Navigate replace />, useLocation().search may not reflect
+      // the updated URL at render time, but window.location.search is always
+      // current. This ensures OIDC params survive the login -> TOTP flow.
+      const currentParams = new URLSearchParams(window.location.search);
+      const currentOidcParams = parseOIDCParams(currentParams);
+      const currentRedirectUri =
+        currentParams.get("redirect_uri") || undefined;
+
       if (data.data.totpPending) {
-        if (oidcParams.isOidc) {
-          window.location.replace(`/totp?${oidcParams.compiled}`);
+        if (currentOidcParams.isOidc) {
+          window.location.replace(`/totp?${currentOidcParams.compiled}`);
           return;
         }
         window.location.replace(
-          `/totp${redirectUri ? `?redirect_uri=${encodeURIComponent(redirectUri)}` : ""}`,
+          `/totp${currentRedirectUri ? `?redirect_uri=${encodeURIComponent(currentRedirectUri)}` : ""}`,
         );
         return;
       }
@@ -129,12 +139,12 @@ export const LoginPage = () => {
       });
 
       redirectTimer.current = window.setTimeout(() => {
-        if (oidcParams.isOidc) {
-          window.location.replace(`/authorize?${oidcParams.compiled}`);
+        if (currentOidcParams.isOidc) {
+          window.location.replace(`/authorize?${currentOidcParams.compiled}`);
           return;
         }
         window.location.replace(
-          `/continue${redirectUri ? `?redirect_uri=${encodeURIComponent(redirectUri)}` : ""}`,
+          `/continue${currentRedirectUri ? `?redirect_uri=${encodeURIComponent(currentRedirectUri)}` : ""}`,
         );
       }, 500);
     },


### PR DESCRIPTION
## Bug

When a user with TOTP enabled tries to log in to an app via tinyauth's OIDC provider, the first login attempt always fails with a "State does not match" error on the client app (e.g. Vikunja, Calibre-Web). The second attempt works fine.

This affects **all OIDC client apps** connected to tinyauth when the user has TOTP enabled and is not yet logged in to tinyauth.

## Root Cause

The OIDC authorization flow goes through these pages:

1. `/authorize?scope=...&client_id=...&state=...` → user not logged in
2. React Router `<Navigate>` to `/login?scope=...&client_id=...&state=...`
3. User enters password → server responds with `{ totpPending: true }`
4. `onSuccess` callback redirects to `/totp?...`

The problem is in step 4. The `onSuccess` callback uses `oidcParams` from a closure that was captured at render time via `useLocation().search`. However, when the authorize page redirects to the login page via React Router's `<Navigate replace />`, the `useLocation()` hook can return stale search params that don't include the OIDC parameters.

As a result, `oidcParams.isOidc` is `false` in the callback, and the redirect falls through to the else-branch which only passes `redirect_uri`:

```
// What happens (broken):
/totp?redirect_uri=https://app.example.com/callback

// What should happen (fixed):
/totp?scope=openid+email+profile&response_type=code&client_id=...&redirect_uri=...&state=...
```

After TOTP verification, the TOTP page sees `oidcParams.isOidc = false` (missing params) and redirects to `/continue` instead of `/authorize?...`. The user ends up back at the app without a valid OIDC code/state, causing the "State does not match" error.

The second attempt works because the user is already logged in at tinyauth — the authorize page shows directly (no login/TOTP needed), so no params are lost.

## Fix

Re-parse OIDC params from `window.location.search` inside the `onSuccess` callback instead of relying on the potentially stale closure from `useLocation()`. `window.location.search` is always current and reliably contains the OIDC parameters.

To make the parsing function callable outside of React components, the existing `useOIDCParams` hook logic is extracted into a plain `parseOIDCParams` function. `useOIDCParams` becomes a thin wrapper around it (no breaking changes).

## Verified

Tested end-to-end with Playwright against a live tinyauth + Vikunja setup:

- Clean browser state (no cookies/storage)
- Vikunja → tinyauth login → TOTP → authorize → Vikunja callback
- All OIDC params (`scope`, `client_id`, `state`, `redirect_uri`) preserved through the entire flow
- User successfully logged in on first attempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured OIDC parameter parsing logic for improved code reusability and maintainability.
  * Enhanced login flow to ensure OIDC parameters are freshly evaluated during authentication completion, improving reliability of OAuth/OIDC integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->