### PR TITLE
fix: narrow down action permissions to per-job ones

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,12 +5,13 @@ on:
     - cron: "0 0 * * *"
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,6 +146,8 @@ jobs:
     needs:
       - create-release
       - generate-metadata
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -203,6 +206,8 @@ jobs:
       - create-release
       - generate-metadata
       - image-build
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -261,6 +266,8 @@ jobs:
     needs:
       - create-release
       - generate-metadata
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -319,6 +326,8 @@ jobs:
       - create-release
       - generate-metadata
       - image-build-arm
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -377,6 +386,8 @@ jobs:
     needs:
       - image-build
       - image-build-arm
+    permissions:
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -416,6 +427,8 @@ jobs:
     needs:
       - image-build-distroless
       - image-build-arm-distroless
+    permissions:
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -455,6 +468,8 @@ jobs:
     needs:
       - binary-build
       - binary-build-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   generate-metadata:
@@ -117,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-metadata
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -172,6 +173,8 @@ jobs:
     needs:
       - generate-metadata
       - image-build
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -227,6 +230,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs:
       - generate-metadata
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -282,6 +287,8 @@ jobs:
     needs:
       - generate-metadata
       - image-build-arm
+    permissions:
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -338,6 +345,8 @@ jobs:
     needs:
       - image-build
       - image-build-arm
+    permissions:
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -379,6 +388,8 @@ jobs:
     needs:
       - image-build-distroless
       - image-build-arm-distroless
+    permissions:
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -422,6 +433,8 @@ jobs:
     needs:
       - binary-build
       - binary-build-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -3,12 +3,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   generate-sponsors:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,12 +4,14 @@ on:
     - cron: 0 10 * * *
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security posture by implementing least-privilege permissions across CI/CD workflows. Permission scopes have been tightened at the workflow level and selectively granted only to jobs that require them, reducing potential exposure in automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->