### PR TITLE
bootstrap: set UNIX socket permissions to 770

### DIFF
--- a/internal/bootstrap/app_bootstrap.go
+++ b/internal/bootstrap/app_bootstrap.go
@@ -215,6 +215,12 @@ func (app *BootstrapApp) Setup() error {
 		}
 
 		tlog.App.Info().Msgf("Starting server on unix socket %s", app.config.Server.SocketPath)
+		go func() {
+			// Ensure processes running as a different user can access the socket.
+			if err := os.Chmod(app.config.Server.SocketPath, 0770); err != nil {
+				tlog.App.Fatal().Err(err).Msg("Failed to update UNIX socket permissions")
+			}
+		}()
 		if err := router.RunUnix(app.config.Server.SocketPath); err != nil {
 			tlog.App.Fatal().Err(err).Msg("Failed to start server")
 		}


### PR DESCRIPTION
This grants other processes access to the socket, provided they are in the correct group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UNIX socket permission configuration when the application is configured to run on a UNIX socket, with improved error handling for permission operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->