### PR TITLE
OIDC open redirect fix.

### DIFF
--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -296,6 +296,11 @@ func (service *OIDCService) ValidateAuthorizeParams(req AuthorizeRequest) error 
 	if !ok {
 		return errors.New("access_denied")
 	}
+	
+	// Redirect URI to verify that it's trusted
+	if !slices.Contains(client.TrustedRedirectURIs, req.RedirectURI) {
+		return errors.New("invalid_request_uri")
+	}
 
 	// Scopes
 	scopes := strings.Split(req.Scope, " ")
@@ -316,11 +321,6 @@ func (service *OIDCService) ValidateAuthorizeParams(req AuthorizeRequest) error 
 	// Response type
 	if !slices.Contains(SupportedResponseTypes, req.ResponseType) {
 		return errors.New("unsupported_response_type")
-	}
-
-	// Redirect URI
-	if !slices.Contains(client.TrustedRedirectURIs, req.RedirectURI) {
-		return errors.New("invalid_request_uri")
 	}
 
 	// PKCE code challenge method if set


### PR DESCRIPTION
Open redirect in the OIDC authorize endpoint that can allow phishing linking that would look real and came from the correct domain but redirect to the attackers website.

This was verified and audited by a human, but was caught by an customized Gwen Toolset.

The bug is the order of checks in `ValidateAuthorizeParams`.

`internal/service/oidc_service.go:293`

```
client_id     -> checked
scope         -> checked
response_type -> checked   <-- returns "unsupported_response_type" here
redirect_uri  -> checked   <-- never reached if response_type fails
pkce method   -> checked
```

`internal/controller/oidc_controller.go:155`

```go
if err != nil {
    if err.Error() != "invalid_request_uri" {
        controller.authorizeError(c, err, "...", "...",
            req.RedirectURI,   // attacker-supplied, never validated
            err.Error(), req.State)
        return
    }
}
```

`internal/controller/oidc_controller.go:481` (`authorizeError`)

```go
c.JSON(200, gin.H{
    "redirect_uri": fmt.Sprintf("%s?%s", callback, queries.Encode()),
})
```

`frontend/src/pages/authorize-page.tsx:112`

```tsx
window.location.replace(data.data.redirect_uri);
```

When `scope` or `response_type` is invalid, the function returns before the `redirect_uri` check ever runs. The controller forwards the unvalidated `redirect_uri` to `authorizeError`, which puts it in the JSON response, and the frontend redirects the browser to it.

I should note this did not require an security advisory as it requires the specific client_id to be known for that specific target to get them to click the link and for them to ignore the redirect. This would also only work against local and LDAP accounts without 2FA on top of that.