### PR TITLE
fix: use loaded public key in oidc service, fixes #860

### DIFF
--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -121,7 +121,7 @@ type OIDCService struct {
 
 	clients    map[string]model.OIDCClientConfig
 	privateKey *rsa.PrivateKey
-	publicKey  crypto.PublicKey
+	publicKey  *rsa.PublicKey
 	issuer     string
 }
 
@@ -271,7 +271,7 @@ func NewOIDCService(
 
 		clients:    clients,
 		privateKey: privateKey,
-		publicKey:  publicKey,
+		publicKey:  publicKey.(*rsa.PublicKey),
 		issuer:     issuer,
 	}
 
@@ -296,7 +296,7 @@ func (service *OIDCService) ValidateAuthorizeParams(req AuthorizeRequest) error 
 	if !ok {
 		return errors.New("access_denied")
 	}
-	
+
 	// Redirect URI to verify that it's trusted
 	if !slices.Contains(client.TrustedRedirectURIs, req.RedirectURI) {
 		return errors.New("invalid_request_uri")
@@ -455,7 +455,7 @@ func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user 
 
 	hasher := sha256.New()
 
-	der := x509.MarshalPKCS1PublicKey(&service.privateKey.PublicKey)
+	der := x509.MarshalPKCS1PublicKey(service.publicKey)
 
 	if der == nil {
 		return "", errors.New("failed to marshal public key")
@@ -813,7 +813,7 @@ func (service *OIDCService) cleanupRoutine() {
 func (service *OIDCService) GetJWK() ([]byte, error) {
 	hasher := sha256.New()
 
-	der := x509.MarshalPKCS1PublicKey(&service.privateKey.PublicKey)
+	der := x509.MarshalPKCS1PublicKey(service.publicKey)
 
 	if der == nil {
 		return nil, errors.New("failed to marshal public key")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of public key storage and marshaling in OIDC service for token and JWK generation.
  * Minor cleanup of whitespace in authorization parameter validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyauthapp/tinyauth/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->