### PR TITLE
feat: support provider-specific OAuth whitelists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,10 @@ TINYAUTH_OAUTH_PROVIDERS_name_CLIENTID=
 TINYAUTH_OAUTH_PROVIDERS_name_CLIENTSECRET=
 # Path to the file containing the OAuth client secret.
 TINYAUTH_OAUTH_PROVIDERS_name_CLIENTSECRETFILE=
+# Comma-separated list of allowed OAuth domains for this provider.
+TINYAUTH_OAUTH_PROVIDERS_name_WHITELIST=
+# Path to the OAuth whitelist file for this provider.
+TINYAUTH_OAUTH_PROVIDERS_name_WHITELISTFILE=
 # OAuth scopes.
 TINYAUTH_OAUTH_PROVIDERS_name_SCOPES=
 # OAuth redirect URL.

--- a/internal/bootstrap/app_bootstrap.go
+++ b/internal/bootstrap/app_bootstrap.go
@@ -117,6 +117,13 @@ func (app *BootstrapApp) Setup() error {
 	app.runtime.OAuthProviders = app.config.OAuth.Providers
 
 	for id, provider := range app.runtime.OAuthProviders {
+		providerWhitelist, err := utils.GetStringList(provider.Whitelist, provider.WhitelistFile)
+		if err != nil {
+			return fmt.Errorf("failed to load oauth whitelist for provider %s: %w", id, err)
+		}
+
+		provider.Whitelist = providerWhitelist
+
 		secret := utils.GetSecret(provider.ClientSecret, provider.ClientSecretFile)
 		provider.ClientSecret = secret
 		provider.ClientSecretFile = ""

--- a/internal/controller/oauth_controller.go
+++ b/internal/controller/oauth_controller.go
@@ -183,9 +183,23 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 		return
 	}
 
-	if !controller.auth.IsEmailWhitelisted(req.Provider, user.Email) {
+	svc, err := controller.auth.GetOAuthService(sessionIdCookie)
+
+	if err != nil {
+		controller.log.App.Error().Err(err).Msg("Failed to get OAuth service for session")
+		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/error", controller.runtime.AppURL))
+		return
+	}
+
+	if svc.ID() != req.Provider {
+		controller.log.App.Warn().Msgf("OAuth provider mismatch: expected %s, got %s", req.Provider, svc.ID())
+		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/error", controller.runtime.AppURL))
+		return
+	}
+
+	if !controller.auth.IsEmailWhitelisted(svc.ID(), user.Email) {
 		controller.log.App.Warn().Str("email", user.Email).Msg("Email not whitelisted, denying access")
-		controller.log.AuditLoginFailure(user.Email, req.Provider, c.ClientIP(), "email not whitelisted")
+		controller.log.AuditLoginFailure(user.Email, svc.ID(), c.ClientIP(), "email not whitelisted")
 
 		queries, err := query.Values(UnauthorizedQuery{
 			Username: user.Email,
@@ -224,20 +238,6 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 	} else {
 		controller.log.App.Debug().Msg("No preferred username from OAuth provider, generating from email")
 		username = strings.Replace(user.Email, "@", "_", 1)
-	}
-
-	svc, err := controller.auth.GetOAuthService(sessionIdCookie)
-
-	if err != nil {
-		controller.log.App.Error().Err(err).Msg("Failed to get OAuth service for session")
-		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/error", controller.runtime.AppURL))
-		return
-	}
-
-	if svc.ID() != req.Provider {
-		controller.log.App.Warn().Msgf("OAuth provider mismatch: expected %s, got %s", req.Provider, svc.ID())
-		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/error", controller.runtime.AppURL))
-		return
 	}
 
 	sessionCookie := repository.Session{

--- a/internal/controller/oauth_controller.go
+++ b/internal/controller/oauth_controller.go
@@ -183,7 +183,7 @@ func (controller *OAuthController) oauthCallbackHandler(c *gin.Context) {
 		return
 	}
 
-	if !controller.auth.IsEmailWhitelisted(user.Email) {
+	if !controller.auth.IsEmailWhitelisted(req.Provider, user.Email) {
 		controller.log.App.Warn().Str("email", user.Email).Msg("Email not whitelisted, denying access")
 		controller.log.AuditLoginFailure(user.Email, req.Provider, c.ClientIP(), "email not whitelisted")
 

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -205,7 +205,7 @@ func (m *ContextMiddleware) cookieAuth(ctx context.Context, uuid string, ip stri
 			return nil, nil, fmt.Errorf("oauth provider from session cookie not found: %s", userContext.OAuth.ID)
 		}
 
-		if !m.auth.IsEmailWhitelisted(userContext.OAuth.Email) {
+		if !m.auth.IsEmailWhitelisted(userContext.OAuth.ID, userContext.OAuth.Email) {
 			m.auth.DeleteSession(ctx, uuid)
 			return nil, nil, fmt.Errorf("email from session cookie not whitelisted: %s", userContext.OAuth.Email)
 		}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -226,6 +226,8 @@ type OAuthServiceConfig struct {
 	ClientID         string   `description:"OAuth client ID." yaml:"clientId"`
 	ClientSecret     string   `description:"OAuth client secret." yaml:"clientSecret"`
 	ClientSecretFile string   `description:"Path to the file containing the OAuth client secret." yaml:"clientSecretFile"`
+	Whitelist        []string `description:"Comma-separated list of allowed OAuth domains for this provider." yaml:"whitelist"`
+	WhitelistFile    string   `description:"Path to the OAuth whitelist file for this provider." yaml:"whitelistFile"`
 	Scopes           []string `description:"OAuth scopes." yaml:"scopes"`
 	RedirectURL      string   `description:"OAuth redirect URL." yaml:"redirectUrl"`
 	AuthURL          string   `description:"OAuth authorization URL." yaml:"authUrl"`

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -285,10 +285,15 @@ func (auth *AuthService) RecordLoginAttempt(identifier string, success bool) {
 	}
 }
 
-func (auth *AuthService) IsEmailWhitelisted(email string) bool {
-	match, err := utils.CheckFilter(strings.Join(auth.runtime.OAuthWhitelist, ","), email)
+func (auth *AuthService) IsEmailWhitelisted(provider string, email string) bool {
+	whitelist := auth.runtime.OAuthWhitelist
+	if providerConfig, ok := auth.runtime.OAuthProviders[provider]; ok && len(providerConfig.Whitelist) > 0 {
+		whitelist = providerConfig.Whitelist
+	}
+
+	match, err := utils.CheckFilter(strings.Join(whitelist, ","), email)
 	if err != nil {
-		auth.log.App.Warn().Err(err).Str("email", email).Msg("Invalid email filter pattern")
+		auth.log.App.Warn().Err(err).Str("provider", provider).Str("email", email).Msg("Invalid email filter pattern")
 		return false
 	}
 	return match

--- a/internal/service/auth_service_test.go
+++ b/internal/service/auth_service_test.go
@@ -23,6 +23,9 @@ func TestIsEmailWhitelistedUsesProviderSpecificList(t *testing.T) {
 				"pocketid": {
 					Whitelist: []string{"pocket@example.com"},
 				},
+				"gitlab": {
+					Whitelist: []string{},
+				},
 			},
 		},
 	}
@@ -31,4 +34,6 @@ func TestIsEmailWhitelistedUsesProviderSpecificList(t *testing.T) {
 	assert.False(t, auth.IsEmailWhitelisted("github", "pocket@example.com"))
 	assert.True(t, auth.IsEmailWhitelisted("pocketid", "pocket@example.com"))
 	assert.True(t, auth.IsEmailWhitelisted("google", "global@example.com"))
+	assert.True(t, auth.IsEmailWhitelisted("gitlab", "global@example.com"))
+	assert.False(t, auth.IsEmailWhitelisted("gitlab", "unknown@example.com"))
 }

--- a/internal/service/auth_service_test.go
+++ b/internal/service/auth_service_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinyauthapp/tinyauth/internal/model"
+	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
+)
+
+func TestIsEmailWhitelistedUsesProviderSpecificList(t *testing.T) {
+	log := logger.NewLogger().WithTestConfig()
+	log.Init()
+
+	auth := &AuthService{
+		log: log,
+		runtime: model.RuntimeConfig{
+			OAuthWhitelist: []string{"global@example.com"},
+			OAuthProviders: map[string]model.OAuthServiceConfig{
+				"github": {
+					Whitelist: []string{"github@example.com"},
+				},
+				"pocketid": {
+					Whitelist: []string{"pocket@example.com"},
+				},
+			},
+		},
+	}
+
+	assert.True(t, auth.IsEmailWhitelisted("github", "github@example.com"))
+	assert.False(t, auth.IsEmailWhitelisted("github", "pocket@example.com"))
+	assert.True(t, auth.IsEmailWhitelisted("pocketid", "pocket@example.com"))
+	assert.True(t, auth.IsEmailWhitelisted("google", "global@example.com"))
+}


### PR DESCRIPTION
## Summary
- Add per-provider OAuth whitelist and whitelist file config fields.
- Use a provider-specific whitelist during OAuth callbacks and session validation when one is configured; otherwise keep the existing global OAuth whitelist behavior.
- Document the new provider-level env vars in .env.example.

Closes #622

## Validation
- go test ./internal/service -run TestIsEmailWhitelistedUsesProviderSpecificList -count=1
- go test ./internal/service ./internal/controller ./internal/model ./internal/utils ./internal/utils/decoders
- go test ./... (with a temporary internal/assets/dist/index.html placeholder so the Go embed target exists in a fresh checkout; removed before commit)
- git diff HEAD^ --check

## AI assistance
OpenAI GPT-5 assisted with repository navigation, drafting the focused regression test, and summarizing validation. I reviewed the change and take responsibility for the submitted code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-OAuth-provider email allowlists: configure provider-specific whitelists via TINYAUTH_OAUTH_PROVIDERS_<name>_WHITELIST and TINYAUTH_OAUTH_PROVIDERS_<name>_WHITELISTFILE. Provider-specific lists load from inline values or files and take precedence over the global whitelist when present.
  * OAuth session and callback flows now validate emails against the provider-specific allowlist.

* **Tests**
  * Added unit test verifying provider-specific whitelist behavior and global fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyauthapp/tinyauth/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->