### PR TITLE
fix: ensure domain defined in acls is included in host rules

### DIFF
--- a/internal/service/kubernetes_service.go
+++ b/internal/service/kubernetes_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -167,11 +168,78 @@ func (k *KubernetesService) getByAppName(appName string) *model.App {
 	return nil
 }
 
+func (k *KubernetesService) extractPaths(rule map[string]any) ([]string, error) {
+	http, found, err := unstructured.NestedMap(rule, "http")
+	if err != nil {
+		return nil, fmt.Errorf("reading http from rule: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	paths, found, err := unstructured.NestedSlice(http, "paths")
+	if err != nil {
+		return nil, fmt.Errorf("reading http.paths: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	var result []string
+	for _, p := range paths {
+		path, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if p, ok := path["path"].(string); ok && p != "" {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (k *KubernetesService) extractHosts(item *unstructured.Unstructured) ([]string, error) {
+	rules, found, err := unstructured.NestedSlice(item.Object, "spec", "rules")
+	if err != nil {
+		return nil, fmt.Errorf("reading spec.rules: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	var hosts []string
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if host, ok := rule["host"].(string); ok && host != "" {
+			hosts = append(hosts, host)
+		}
+		paths, err := k.extractPaths(rule)
+		if err != nil {
+			// This is purely to warn users, it doesn't affect our ability to extract hosts so we won't fail the whole operation
+			k.log.App.Warn().Err(err).Str("namespace", item.GetNamespace()).Str("name", item.GetName()).Msg("Failed to extract paths from ingress rule")
+			continue
+		}
+		if len(paths) == 0 {
+			continue
+		}
+		if !slices.Contains(paths, "/") {
+			k.log.App.Warn().Str("namespace", item.GetNamespace()).Str("name", item.GetName()).Strs("paths", paths).Msg("Ingress rule does not contain a catch-all path, another ingress may be able to bypass auth checks if it routes the same host with a different path. Consider adding a catch-all path to this rule to ensure auth checks are applied to all paths for this host.")
+		}
+	}
+	k.log.App.Trace().Strs("hosts", hosts).Msg("Extracted hosts from ingress rules")
+	return hosts, nil
+}
+
 func (k *KubernetesService) updateFromItem(item *unstructured.Unstructured) {
 	namespace := item.GetNamespace()
 	name := item.GetName()
 	annotations := item.GetAnnotations()
 	if annotations == nil {
+		k.removeIngress(namespace, name)
+		return
+	}
+	hosts, err := k.extractHosts(item)
+	if err != nil {
 		k.removeIngress(namespace, name)
 		return
 	}
@@ -184,6 +252,10 @@ func (k *KubernetesService) updateFromItem(item *unstructured.Unstructured) {
 	var apps []ingressApp
 	for appName, appLabels := range labels.Apps {
 		if appLabels.Config.Domain == "" {
+			continue
+		}
+		if len(hosts) > 0 && !slices.Contains(hosts, appLabels.Config.Domain) {
+			k.log.App.Warn().Str("namespace", namespace).Str("name", name).Str("appName", appName).Str("domain", appLabels.Config.Domain).Msg("App domain does not match any hosts defined in ingress rules, skipping")
 			continue
 		}
 		apps = append(apps, ingressApp{


### PR DESCRIPTION
Fixes https://github.com/tinyauthapp/tinyauth/security/advisories/GHSA-pcj4-r7vg-3jvw

@sondt99 please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes Ingress parsing with enhanced hostname extraction and validation
  * Added domain matching validation to ensure apps only use correctly configured ingress entries
  * Enhanced warning messages for incomplete ingress rule configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyauthapp/tinyauth/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->