### PR TITLE
fix: potential nil pointer dereferences

### DIFF
--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -251,6 +251,10 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 	case model.UserLocal:
 		user := m.auth.GetLocalUser(username)
 
+		if user == nil {
+			return nil, nil, fmt.Errorf("user not found locally: %s", username)
+		}
+
 		if user.TOTPSecret != "" {
 			return nil, nil, fmt.Errorf("user with totp not allowed to login via basic auth: %s", username)
 		}

--- a/internal/service/access_controls_rules.go
+++ b/internal/service/access_controls_rules.go
@@ -114,7 +114,7 @@ type LDAPGroupRule struct {
 }
 
 func (rule *LDAPGroupRule) Evaluate(ctx *ACLContext) Effect {
-	if ctx == nil || ctx.UserContext == nil {
+	if ctx == nil || ctx.UserContext == nil || ctx.ACLs == nil {
 		return EffectAbstain
 	}
 


### PR DESCRIPTION
in light of the bug fixed in 2737a25227c017e333518fd2778a785a2caacd29, i decided to look for other potential areas where we may not be defensively checking for nil pointers.

The first case where the user is nil is extremely unlikely, but under specific race conditions, the TOTP check may try to deref a nil pointer to user. E.g. `GetLocalUser` returns `nil` after `SearchUser` succeeds when `LocalUsers` is modified concurrently. At this point accessing `user.TOTPSecret` on `nil` panics.

Second case is more obvious, `ctx.ACLs` isn't checked for `nil` for ldap groups. It's deref'd later in the function without a defensive nil check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of user authentication by properly handling cases where local user accounts are missing
  * Enhanced null safety checks in access control rule evaluation to prevent potential application crashes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyauthapp/tinyauth/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->