### PR TITLE
Add LDAP BindPasswordFile

### DIFF
--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -178,15 +178,16 @@ type UIConfig struct {
 }
 
 type LDAPConfig struct {
-	Address       string `description:"LDAP server address." yaml:"address"`
-	BindDN        string `description:"Bind DN for LDAP authentication." yaml:"bindDn"`
-	BindPassword  string `description:"Bind password for LDAP authentication." yaml:"bindPassword"`
-	BaseDN        string `description:"Base DN for LDAP searches." yaml:"baseDn"`
-	Insecure      bool   `description:"Allow insecure LDAP connections." yaml:"insecure"`
-	SearchFilter  string `description:"LDAP search filter." yaml:"searchFilter"`
-	AuthCert      string `description:"Certificate for mTLS authentication." yaml:"authCert"`
-	AuthKey       string `description:"Certificate key for mTLS authentication." yaml:"authKey"`
-	GroupCacheTTL int    `description:"Cache duration for LDAP group membership in seconds." yaml:"groupCacheTTL"`
+	Address      	 string `description:"LDAP server address." yaml:"address"`
+	BindDN       	 string `description:"Bind DN for LDAP authentication." yaml:"bindDn"`
+	BindPassword  	 string `description:"Bind password for LDAP authentication." yaml:"bindPassword"`
+	BindPasswordFile string `description:"Path to the Bind password." yaml:"bindPasswordFile"`
+	BaseDN       	 string `description:"Base DN for LDAP searches." yaml:"baseDn"`
+	Insecure     	 bool   `description:"Allow insecure LDAP connections." yaml:"insecure"`
+	SearchFilter 	 string `description:"LDAP search filter." yaml:"searchFilter"`
+	AuthCert     	 string `description:"Certificate for mTLS authentication." yaml:"authCert"`
+	AuthKey      	 string `description:"Certificate key for mTLS authentication." yaml:"authKey"`
+	GroupCacheTTL	 int    `description:"Cache duration for LDAP group membership in seconds." yaml:"groupCacheTTL"`
 }
 
 type LogConfig struct {

--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -33,6 +33,10 @@ func NewLdapService(
 		return nil, nil
 	}
 
+	secret := utils.GetSecret(config.LDAP.BindPassword, config.LDAP.BindPasswordFile)
+	config.LDAP.BindPassword = secret
+	config.LDAP.BindPasswordFile = ""
+
 	ldap := &LdapService{
 		log:    log,
 		config: config,
@@ -61,10 +65,6 @@ func NewLdapService(
 			}
 		*/
 	}
-
-	secret := utils.GetSecret(config.LDAP.BindPassword, config.LDAP.BindPasswordFile)
-	config.LDAP.BindPassword = secret
-	config.LDAP.BindPasswordFile = ""
 
 	_, err := ldap.connect()
 

--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -62,6 +62,10 @@ func NewLdapService(
 		*/
 	}
 
+	secret := utils.GetSecret(config.LDAP.BindPassword, config.LDAP.BindPasswordFile)
+	config.LDAP.BindPassword = secret
+	config.LDAP.BindPasswordFile = ""
+
 	_, err := ldap.connect()
 
 	if err != nil {
@@ -213,9 +217,6 @@ func (ldap *LdapService) BindService(rebind bool) error {
 	if ldap.cert != nil {
 		return ldap.conn.ExternalBind()
 	}
-	secret := utils.GetSecret(ldap.config.LDAP.BindPassword, ldap.config.LDAP.BindPasswordFile)
-	ldap.config.LDAP.BindPassword = secret
-	ldap.config.LDAP.BindPasswordFile = ""
 	return ldap.conn.Bind(ldap.config.LDAP.BindDN, ldap.config.LDAP.BindPassword)
 }
 

--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -11,6 +11,7 @@ import (
 	ldapgo "github.com/go-ldap/ldap/v3"
 	"github.com/steveiliop56/ding"
 	"github.com/tinyauthapp/tinyauth/internal/model"
+	"github.com/tinyauthapp/tinyauth/internal/utils"
 	"github.com/tinyauthapp/tinyauth/internal/utils/logger"
 )
 

--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -212,6 +212,9 @@ func (ldap *LdapService) BindService(rebind bool) error {
 	if ldap.cert != nil {
 		return ldap.conn.ExternalBind()
 	}
+	secret := utils.GetSecret(ldap.config.LDAP.BindPassword, ldap.config.LDAP.BindPasswordFile)
+	ldap.config.LDAP.BindPassword = secret
+	ldap.config.LDAP.BindPasswordFile = ""
 	return ldap.conn.Bind(ldap.config.LDAP.BindDN, ldap.config.LDAP.BindPassword)
 }
 


### PR DESCRIPTION
Fixes #927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LDAP bind password can now be supplied via a file path as an alternative to embedding the password in configuration.

* **Bug Fixes / Behavior**
  * When a file path is provided, the password is loaded into memory before binding and the file-based reference is cleared so subsequent operations use the in-memory secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->