### PR TITLE
feat: support for the prompt parameter in the oidc flow

### DIFF
--- a/frontend/src/lib/hooks/screen-params.ts
+++ b/frontend/src/lib/hooks/screen-params.ts
@@ -6,6 +6,7 @@ type ScreenParams = {
   oidc_ticket?: string;
   oidc_scope?: string;
   oidc_name?: string;
+  oidc_login?: boolean;
 };
 
 const zodScreenParams = z.object({
@@ -14,6 +15,7 @@ const zodScreenParams = z.object({
   oidc_ticket: z.string().optional(),
   oidc_scope: z.string().optional(),
   oidc_name: z.string().optional(),
+  oidc_login: z.stringbool().optional(),
 });
 
 export function useScreenParams(params: URLSearchParams): ScreenParams {

--- a/frontend/src/lib/hooks/screen-params.ts
+++ b/frontend/src/lib/hooks/screen-params.ts
@@ -6,7 +6,7 @@ type ScreenParams = {
   oidc_ticket?: string;
   oidc_scope?: string;
   oidc_name?: string;
-  oidc_login?: boolean;
+  oidc_prompt?: "none" | "login";
 };
 
 const zodScreenParams = z.object({
@@ -15,7 +15,7 @@ const zodScreenParams = z.object({
   oidc_ticket: z.string().optional(),
   oidc_scope: z.string().optional(),
   oidc_name: z.string().optional(),
-  oidc_login: z.stringbool().optional(),
+  oidc_prompt: z.enum(["none", "login"]).optional(),
 });
 
 export function useScreenParams(params: URLSearchParams): ScreenParams {

--- a/frontend/src/pages/authorize-page.tsx
+++ b/frontend/src/pages/authorize-page.tsx
@@ -25,6 +25,7 @@ import {
   recompileScreenParams,
   useScreenParams,
 } from "@/lib/hooks/screen-params";
+import { useEffect } from "react";
 
 type Scope = {
   id: string;
@@ -90,7 +91,15 @@ export const AuthorizePage = () => {
   const isOidc = screenParams.login_for === "oidc";
   const compiledParams = recompileScreenParams(screenParams);
 
-  const authorizeMutation = useMutation({
+  // TODO: maybe a better way to do this
+  const shouldAutoAuthorize =
+    auth.authenticated &&
+    isOidc &&
+    screenParams.oidc_ticket !== undefined &&
+    screenParams.oidc_scope !== undefined &&
+    screenParams.oidc_prompt === "none";
+
+  const { mutate: authorizeMutate, isPending: authorizePending } = useMutation({
     mutationFn: () => {
       return axios.post("/api/oidc/authorize-complete", {
         ticket: screenParams.oidc_ticket,
@@ -110,6 +119,12 @@ export const AuthorizePage = () => {
     },
   });
 
+  useEffect(() => {
+    if (shouldAutoAuthorize) {
+      authorizeMutate();
+    }
+  }, [shouldAutoAuthorize, authorizeMutate]);
+
   if (!isOidc || !screenParams.oidc_ticket || !screenParams.oidc_scope) {
     return (
       <Navigate
@@ -119,7 +134,7 @@ export const AuthorizePage = () => {
     );
   }
 
-  if (!auth.authenticated || screenParams.oidc_login) {
+  if (!auth.authenticated || screenParams.oidc_prompt === "login") {
     return <Navigate to={`/login${compiledParams}`} replace />;
   }
 
@@ -168,14 +183,15 @@ export const AuthorizePage = () => {
       )}
       <CardFooter className="flex flex-col items-stretch gap-3">
         <Button
-          onClick={() => authorizeMutation.mutate()}
-          loading={authorizeMutation.isPending}
+          onClick={() => authorizeMutate()}
+          loading={authorizePending}
+          disabled={shouldAutoAuthorize}
         >
           {t("authorizeTitle")}
         </Button>
         <Button
           onClick={() => navigate(`/logout${compiledParams}`)}
-          disabled={authorizeMutation.isPending}
+          disabled={authorizePending || shouldAutoAuthorize}
           variant="outline"
         >
           {t("cancelTitle")}

--- a/frontend/src/pages/authorize-page.tsx
+++ b/frontend/src/pages/authorize-page.tsx
@@ -119,7 +119,7 @@ export const AuthorizePage = () => {
     );
   }
 
-  if (!auth.authenticated) {
+  if (!auth.authenticated || screenParams.oidc_login) {
     return <Navigate to={`/login${compiledParams}`} replace />;
   }
 

--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -65,7 +65,7 @@ export const LoginPage = () => {
   const screenParams = useScreenParams(searchParams);
   const compiledParams = recompileScreenParams({
     ...screenParams,
-    oidc_login: false,
+    oidc_prompt: undefined,
   });
   const loginForUrl = useLoginFor({
     login_for: screenParams.login_for,
@@ -199,7 +199,7 @@ export const LoginPage = () => {
     };
   }, [redirectTimer, redirectButtonTimer]);
 
-  if (auth.authenticated && !screenParams.oidc_login) {
+  if (auth.authenticated && screenParams.oidc_prompt !== "login") {
     return <Navigate to={loginForUrl} replace />;
   }
 

--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -63,7 +63,10 @@ export const LoginPage = () => {
 
   const searchParams = new URLSearchParams(search);
   const screenParams = useScreenParams(searchParams);
-  const compiledParams = recompileScreenParams(screenParams);
+  const compiledParams = recompileScreenParams({
+    ...screenParams,
+    oidc_login: false,
+  });
   const loginForUrl = useLoginFor({
     login_for: screenParams.login_for,
     compiledParams,
@@ -196,7 +199,7 @@ export const LoginPage = () => {
     };
   }, [redirectTimer, redirectButtonTimer]);
 
-  if (auth.authenticated) {
+  if (auth.authenticated && !screenParams.oidc_login) {
     return <Navigate to={loginForUrl} replace />;
   }
 

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -69,11 +69,11 @@ type ClientCredentials struct {
 }
 
 type AuthorizeScreenParams struct {
-	LoginFor   FrontendLoginFor `url:"login_for"`
-	OIDCTicket string           `url:"oidc_ticket"`
-	OIDCScope  string           `url:"oidc_scope"`
-	OIDCName   string           `url:"oidc_name"`
-	OIDCLogin  bool             `url:"oidc_login"`
+	LoginFor   FrontendLoginFor   `url:"login_for"`
+	OIDCTicket string             `url:"oidc_ticket"`
+	OIDCScope  string             `url:"oidc_scope"`
+	OIDCName   string             `url:"oidc_name"`
+	OIDCPrompt service.OIDCPrompt `url:"oidc_prompt,omitempty"`
 }
 
 type AuthorizeCompleteRequest struct {
@@ -168,6 +168,8 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		return
 	}
 
+	prompt := controller.oidc.GetPrompt(req.Prompt)
+
 	userContext, err := new(model.UserContext).NewFromGin(c)
 
 	if err != nil {
@@ -176,7 +178,7 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		}
 	}
 
-	if (err != nil || !userContext.Authenticated) && req.Prompt == "none" {
+	if (err != nil || !userContext.Authenticated) && prompt == service.OIDCPromptNone {
 		controller.authorizeError(c, authorizeErrorParams{
 			err:           errors.New("user not logged in"),
 			reason:        "User not logged in",
@@ -195,10 +197,7 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		OIDCTicket: ticket,
 		OIDCScope:  req.Scope,
 		OIDCName:   client.Name,
-	}
-
-	if req.Prompt == "login" {
-		values.OIDCLogin = true
+		OIDCPrompt: prompt,
 	}
 
 	queries, err := query.Values(values)

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -168,6 +168,26 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		return
 	}
 
+	userContext, err := new(model.UserContext).NewFromGin(c)
+
+	if err != nil {
+		if !errors.Is(err, model.ErrUserContextNotFound) {
+			controller.log.App.Warn().Err(err).Msg("Failed to get user context")
+		}
+	}
+
+	if (err != nil || !userContext.Authenticated) && req.Prompt == "none" {
+		controller.authorizeError(c, authorizeErrorParams{
+			err:           errors.New("user not logged in"),
+			reason:        "User not logged in",
+			reasonPublic:  "The user is not logged in",
+			callback:      req.RedirectURI,
+			callbackError: "login_required",
+			state:         req.State,
+		})
+		return
+	}
+
 	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
 
 	values := AuthorizeScreenParams{
@@ -185,9 +205,12 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 
 	if err != nil {
 		controller.authorizeError(c, authorizeErrorParams{
-			err:          err,
-			reason:       "Failed to compile authorize queries",
-			reasonPublic: "An internal error occured while processing your request",
+			err:           err,
+			reason:        "Failed to compile authorize queries",
+			reasonPublic:  "An internal error occured while processing your request",
+			callback:      req.RedirectURI,
+			callbackError: "server_error",
+			state:         req.State,
 		})
 		return
 	}
@@ -215,16 +238,12 @@ func (controller *OIDCController) authorizeComplete(c *gin.Context) {
 	userContext, err := new(model.UserContext).NewFromGin(c)
 
 	if err != nil {
-		controller.authorizeError(c, authorizeErrorParams{
-			err:          err,
-			reason:       "Failed to get user context",
-			reasonPublic: "User is not logged in or the session is invalid",
-			json:         true,
-		})
-		return
+		if !errors.Is(err, model.ErrUserContextNotFound) {
+			controller.log.App.Warn().Err(err).Msg("Failed to get user context")
+		}
 	}
 
-	if !userContext.Authenticated {
+	if err != nil || !userContext.Authenticated {
 		controller.authorizeError(c, authorizeErrorParams{
 			err:          errors.New("err user not logged in"),
 			reason:       "User not logged in",

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -170,6 +170,18 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 
 	prompts := controller.oidc.GetPrompt(req.Prompt)
 
+	if slices.Contains(prompts, service.OIDCPromptNone) && len(prompts) > 1 {
+		controller.authorizeError(c, authorizeErrorParams{
+			err:           errors.New("invalid prompt"),
+			reason:        "Invalid prompt",
+			reasonPublic:  "The prompt parameters are invalid",
+			callback:      req.RedirectURI,
+			callbackError: "invalid_request",
+			state:         req.State,
+		})
+		return
+	}
+
 	userContext, err := new(model.UserContext).NewFromGin(c)
 
 	if err != nil {

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -168,7 +168,7 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		return
 	}
 
-	prompt := controller.oidc.GetPrompt(req.Prompt)
+	prompts := controller.oidc.GetPrompt(req.Prompt)
 
 	userContext, err := new(model.UserContext).NewFromGin(c)
 
@@ -178,7 +178,7 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		}
 	}
 
-	if (err != nil || !userContext.Authenticated) && prompt == service.OIDCPromptNone {
+	if (err != nil || !userContext.Authenticated) && slices.Contains(prompts, service.OIDCPromptNone) {
 		controller.authorizeError(c, authorizeErrorParams{
 			err:           errors.New("user not logged in"),
 			reason:        "User not logged in",
@@ -197,7 +197,12 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		OIDCTicket: ticket,
 		OIDCScope:  req.Scope,
 		OIDCName:   client.Name,
-		OIDCPrompt: prompt,
+	}
+
+	if slices.Contains(prompts, service.OIDCPromptLogin) {
+		values.OIDCPrompt = service.OIDCPromptLogin
+	} else if slices.Contains(prompts, service.OIDCPromptNone) {
+		values.OIDCPrompt = service.OIDCPromptNone
 	}
 
 	queries, err := query.Values(values)

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -73,6 +73,7 @@ type AuthorizeScreenParams struct {
 	OIDCTicket string           `url:"oidc_ticket"`
 	OIDCScope  string           `url:"oidc_scope"`
 	OIDCName   string           `url:"oidc_name"`
+	OIDCLogin  bool             `url:"oidc_login"`
 }
 
 type AuthorizeCompleteRequest struct {
@@ -169,12 +170,18 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 
 	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
 
-	queries, err := query.Values(AuthorizeScreenParams{
+	values := AuthorizeScreenParams{
 		LoginFor:   FrontendLoginForOIDC,
 		OIDCTicket: ticket,
 		OIDCScope:  req.Scope,
 		OIDCName:   client.Name,
-	})
+	}
+
+	if req.Prompt == "login" {
+		values.OIDCLogin = true
+	}
+
+	queries, err := query.Values(values)
 
 	if err != nil {
 		controller.authorizeError(c, authorizeErrorParams{
@@ -425,7 +432,7 @@ func (controller *OIDCController) Token(c *gin.Context) {
 			return
 		}
 
-		tokenRes, err := controller.oidc.GenerateAccessToken(c, client, *entry)
+		tokenRes, err := controller.oidc.GenerateAccessToken(c, client, *entry, entry.AuthTime)
 
 		if err != nil {
 			controller.log.App.Error().Err(err).Msg("Failed to generate access token")

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -25,6 +25,7 @@ const (
 type UserContext struct {
 	Authenticated bool
 	Provider      ProviderType
+	AuthTime      int64
 	Local         *LocalContext
 	OAuth         *OAuthContext
 	LDAP          *LDAPContext
@@ -110,6 +111,7 @@ func (c *UserContext) NewFromGin(ginctx *gin.Context) (*UserContext, error) {
 func (c *UserContext) NewFromSession(session *repository.Session) (*UserContext, error) {
 	*c = UserContext{
 		Authenticated: !session.TotpPending,
+		AuthTime:      session.CreatedAt,
 	}
 
 	switch session.Provider {

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -44,6 +44,15 @@ var (
 	ErrInvalidClient = errors.New("invalid_client")
 )
 
+type OIDCPrompt string
+
+const (
+	OIDCPromptLogin OIDCPrompt = "login"
+	OIDCPromptNone  OIDCPrompt = "none"
+)
+
+var SupportedPrompts = []string{string(OIDCPromptLogin), string(OIDCPromptNone)}
+
 // This is not spec-compliant, the ID token SHOULD NOT contain user info claims but,
 // it has became a "standard" and apps are looking for the claims in the ID tokens
 // instead of calling the userinfo endpoint, so we include them in the ID token as well
@@ -936,4 +945,21 @@ func (service *OIDCService) DecodeAuthorizeJWT(tokenString string) (*AuthorizeRe
 		CodeChallengeMethod: get("code_challenge_method"),
 		Prompt:              get("prompt"),
 	}, nil
+}
+
+// Return the first prompt in the list of prompts, or an empty string if no prompt is specified
+func (service *OIDCService) GetPrompt(prompt string) OIDCPrompt {
+	if prompt == "" {
+		return ""
+	}
+
+	prompts := strings.Split(prompt, " ")
+
+	for _, p := range prompts {
+		if slices.Contains(SupportedPrompts, p) {
+			return OIDCPrompt(p)
+		}
+	}
+
+	return ""
 }

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -54,6 +54,7 @@ type ClaimSet struct {
 	Sub               string   `json:"sub"`
 	Iat               int64    `json:"iat"`
 	Exp               int64    `json:"exp"`
+	AuthTime          int64    `json:"auth_time,omitempty"`
 	Name              string   `json:"name,omitempty"`
 	GivenName         string   `json:"given_name,omitempty"`
 	FamilyName        string   `json:"family_name,omitempty"`
@@ -117,6 +118,7 @@ type AuthorizeRequest struct {
 	Nonce               string `form:"nonce" json:"nonce" url:"nonce"`
 	CodeChallenge       string `form:"code_challenge" json:"code_challenge" url:"code_challenge"`
 	CodeChallengeMethod string `form:"code_challenge_method" json:"code_challenge_method" url:"code_challenge_method"`
+	Prompt              string `form:"prompt" json:"prompt" url:"prompt"`
 }
 
 type AuthorizeCodeEntry struct {
@@ -127,6 +129,7 @@ type AuthorizeCodeEntry struct {
 	Nonce         string
 	CodeChallenge string
 	Userinfo      UserinfoResponse
+	AuthTime      int64
 }
 
 type UsedCodeEntry struct {
@@ -423,6 +426,7 @@ func (service *OIDCService) CreateCode(req AuthorizeRequest, userContext model.U
 		ClientID:    req.ClientID,
 		Nonce:       req.Nonce,
 		Userinfo:    service.userinfoFromContext(userContext, sub),
+		AuthTime:    userContext.AuthTime,
 	}
 
 	if req.CodeChallenge != "" {
@@ -512,7 +516,7 @@ func (service *OIDCService) GetCodeEntry(codeHash string, clientId string) (*Aut
 	return &entry, true
 }
 
-func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user UserinfoResponse, scope string, nonce string) (string, error) {
+func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user UserinfoResponse, scope string, nonce string, auth_time int64) (string, error) {
 	createdAt := time.Now().Unix()
 	expiresAt := time.Now().Add(time.Duration(service.config.Auth.SessionExpiry) * time.Second).Unix()
 
@@ -549,6 +553,7 @@ func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user 
 		Sub:               user.Sub,
 		Iat:               createdAt,
 		Exp:               expiresAt,
+		AuthTime:          auth_time,
 		Name:              userInfo.Name,
 		Email:             userInfo.Email,
 		EmailVerified:     userInfo.EmailVerified,
@@ -578,8 +583,8 @@ func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user 
 	return token, nil
 }
 
-func (service *OIDCService) GenerateAccessToken(ctx context.Context, client model.OIDCClientConfig, codeEntry AuthorizeCodeEntry) (*TokenResponse, error) {
-	idToken, err := service.generateIDToken(client, codeEntry.Userinfo, codeEntry.Scope, codeEntry.Nonce)
+func (service *OIDCService) GenerateAccessToken(ctx context.Context, client model.OIDCClientConfig, codeEntry AuthorizeCodeEntry, authTime int64) (*TokenResponse, error) {
+	idToken, err := service.generateIDToken(client, codeEntry.Userinfo, codeEntry.Scope, codeEntry.Nonce, authTime)
 
 	if err != nil {
 		return nil, err
@@ -660,7 +665,7 @@ func (service *OIDCService) RefreshAccessToken(ctx context.Context, refreshToken
 
 	idToken, err := service.generateIDToken(model.OIDCClientConfig{
 		ClientID: entry.ClientID,
-	}, userInfo, entry.Scope, entry.Nonce)
+	}, userInfo, entry.Scope, entry.Nonce, 0) // auth_time is not available during refresh, so we set it to 0
 
 	if err != nil {
 		return nil, err
@@ -929,5 +934,6 @@ func (service *OIDCService) DecodeAuthorizeJWT(tokenString string) (*AuthorizeRe
 		Nonce:               get("nonce"),
 		CodeChallenge:       get("code_challenge"),
 		CodeChallengeMethod: get("code_challenge_method"),
+		Prompt:              get("prompt"),
 	}, nil
 }

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -525,7 +525,7 @@ func (service *OIDCService) GetCodeEntry(codeHash string, clientId string) (*Aut
 	return &entry, true
 }
 
-func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user UserinfoResponse, scope string, nonce string, auth_time int64) (string, error) {
+func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user UserinfoResponse, scope string, nonce string, authTime *int64) (string, error) {
 	createdAt := time.Now().Unix()
 	expiresAt := time.Now().Add(time.Duration(service.config.Auth.SessionExpiry) * time.Second).Unix()
 
@@ -562,13 +562,16 @@ func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user 
 		Sub:               user.Sub,
 		Iat:               createdAt,
 		Exp:               expiresAt,
-		AuthTime:          auth_time,
 		Name:              userInfo.Name,
 		Email:             userInfo.Email,
 		EmailVerified:     userInfo.EmailVerified,
 		PreferredUsername: userInfo.PreferredUsername,
 		Groups:            userInfo.Groups,
 		Nonce:             nonce,
+	}
+
+	if authTime != nil {
+		claims.AuthTime = *authTime
 	}
 
 	payload, err := json.Marshal(claims)
@@ -593,7 +596,7 @@ func (service *OIDCService) generateIDToken(client model.OIDCClientConfig, user 
 }
 
 func (service *OIDCService) GenerateAccessToken(ctx context.Context, client model.OIDCClientConfig, codeEntry AuthorizeCodeEntry, authTime int64) (*TokenResponse, error) {
-	idToken, err := service.generateIDToken(client, codeEntry.Userinfo, codeEntry.Scope, codeEntry.Nonce, authTime)
+	idToken, err := service.generateIDToken(client, codeEntry.Userinfo, codeEntry.Scope, codeEntry.Nonce, &authTime)
 
 	if err != nil {
 		return nil, err
@@ -672,9 +675,10 @@ func (service *OIDCService) RefreshAccessToken(ctx context.Context, refreshToken
 		return nil, err
 	}
 
+	// TODO: store auth time in the database so we can include it in the new ID token, for now we omit it
 	idToken, err := service.generateIDToken(model.OIDCClientConfig{
 		ClientID: entry.ClientID,
-	}, userInfo, entry.Scope, entry.Nonce, 0) // auth_time is not available during refresh, so we set it to 0
+	}, userInfo, entry.Scope, entry.Nonce, nil)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/oidc_service.go
+++ b/internal/service/oidc_service.go
@@ -947,19 +947,20 @@ func (service *OIDCService) DecodeAuthorizeJWT(tokenString string) (*AuthorizeRe
 	}, nil
 }
 
-// Return the first prompt in the list of prompts, or an empty string if no prompt is specified
-func (service *OIDCService) GetPrompt(prompt string) OIDCPrompt {
+func (service *OIDCService) GetPrompt(prompt string) []OIDCPrompt {
 	if prompt == "" {
-		return ""
+		return []OIDCPrompt{}
 	}
 
-	prompts := strings.Split(prompt, " ")
+	parsedPromps := make([]OIDCPrompt, 0)
+	prompts := strings.SplitSeq(prompt, " ")
 
-	for _, p := range prompts {
-		if slices.Contains(SupportedPrompts, p) {
-			return OIDCPrompt(p)
+	for p := range prompts {
+		if !slices.Contains(SupportedPrompts, p) {
+			continue
 		}
+		parsedPromps = append(parsedPromps, OIDCPrompt(p))
 	}
 
-	return ""
+	return parsedPromps
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for the OpenID Connect `prompt` parameter (`none`/`login`), including URL handling and backend enforcement.
  * ID tokens now include `auth_time`.

* **Improvements**
  * `prompt=none` now returns a standardized “login required” error when silent sign-in isn’t possible.
  * Requests that combine `prompt=none` with other prompt values are rejected as invalid.
  * Updated login/authorize page behavior for auto-authorization, redirects, and disabling actions during auto-authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->