### PR TITLE
feat: show provider in quick actions

### DIFF
--- a/frontend/src/components/icons/local-auth.tsx
+++ b/frontend/src/components/icons/local-auth.tsx
@@ -1,0 +1,22 @@
+import type { SVGProps } from "react";
+
+export function LocalAuthIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0-8 0M6 21v-2a4 4 0 0 1 4-4h5m3.5 3.5L15 22l-1.5-1.5m5.054-2.086a2 2 0 1 1 2.828-2.828a2 2 0 0 1-2.828 2.828M16 19l1 1"
+      ></path>
+    </svg>
+  );
+}

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -189,7 +189,7 @@ export const QuickActions = () => {
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className="rounded-xl p-1"
+        className="rounded-xl p-1 w-3xs"
       >
         {auth.authenticated && (
           <>
@@ -200,11 +200,11 @@ export const QuickActions = () => {
                 </TooltipTrigger>
                 <TooltipContent>{providerDetails!.name}</TooltipContent>
               </Tooltip>
-              <div className="flex min-w-0 flex-col gap-1.5">
-                <span className="truncate text-sm font-medium leading-none">
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <span className="truncate text-sm font-medium">
                   {auth.name}
                 </span>
-                <span className="text-muted-foreground truncate text-xs leading-none">
+                <span className="text-muted-foreground truncate text-xs">
                   {auth.email}
                 </span>
               </div>

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -37,6 +37,13 @@ import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 import { toast } from "sonner";
 import { useEffect } from "react";
+import { GoogleIcon } from "../icons/google";
+import { GithubIcon } from "../icons/github";
+import { TailscaleIcon } from "../icons/tailscale";
+import { MicrosoftIcon } from "../icons/microsoft";
+import { PocketIDIcon } from "../icons/pocket-id";
+import { LocalAuthIcon } from "../icons/local-auth";
+import { OAuthIcon } from "../icons/oauth";
 
 function Avatar({ initial }: { initial: string }) {
   return (
@@ -49,8 +56,18 @@ function Avatar({ initial }: { initial: string }) {
   );
 }
 
+const iconStyles = "size-4";
+
+const iconMap: Record<string, React.ReactNode> = {
+  google: <GoogleIcon className={iconStyles} />,
+  github: <GithubIcon className={iconStyles} />,
+  tailscale: <TailscaleIcon className={iconStyles} />,
+  microsoft: <MicrosoftIcon className={iconStyles} />,
+  pocketid: <PocketIDIcon className={iconStyles} />,
+};
+
 export const QuickActions = () => {
-  const { auth } = useUserContext();
+  const { auth, oauth, tailscale } = useUserContext();
   const { theme, setTheme } = useTheme();
   const { t } = useTranslation();
   const { search } = useLocation();
@@ -63,6 +80,41 @@ export const QuickActions = () => {
   const searchParams = new URLSearchParams(search);
   const screenParams = useScreenParams(searchParams);
   const compiledParams = recompileScreenParams(screenParams);
+
+  const providerDetails = (():
+    | { name: string; icon: React.ReactNode }
+    | undefined => {
+    if (!auth.authenticated) {
+      return undefined;
+    }
+
+    if (auth.providerId === "local" || auth.providerId === "ldap") {
+      return {
+        name: t(
+          auth.providerId === "ldap"
+            ? "quickActionsProviderLDAP"
+            : "quickActionsProviderLocal",
+        ),
+        icon: <LocalAuthIcon className={iconStyles} />,
+      };
+    }
+
+    if (oauth.active) {
+      return {
+        name: t("quickActionsProviderOAuth", { provider: oauth.displayName }),
+        icon: iconMap[auth.providerId] || <OAuthIcon className={iconStyles} />,
+      };
+    }
+
+    if (auth.providerId === "tailscale") {
+      return {
+        name: `Tailscale (${tailscale.nodeName})`,
+        icon: <TailscaleIcon className={iconStyles} />,
+      };
+    }
+
+    return undefined;
+  })();
 
   const logoutMutation = useMutation({
     mutationFn: () => axios.post("/api/user/logout"),
@@ -134,11 +186,19 @@ export const QuickActions = () => {
               <div className="bg-foreground text-background flex size-9 shrink-0 items-center justify-center rounded-full text-sm font-medium">
                 {initial}
               </div>
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate text-sm font-medium">
-                  {auth.name}
-                </span>
-                <span className="text-muted-foreground truncate text-xs font-normal">
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium leading-none">
+                    {auth.name}
+                  </span>
+                  {providerDetails && (
+                    <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1 rounded-lg bg-secondary px-2 py-1.25 text-[10px] font-medium leading-none [&_svg]:size-3">
+                      {providerDetails.icon}
+                      {providerDetails.name}
+                    </span>
+                  )}
+                </div>
+                <span className="text-muted-foreground truncate text-xs leading-none">
                   {auth.email}
                 </span>
               </div>

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -25,6 +25,7 @@ import {
   Palette,
   Settings,
   Sun,
+  X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router";
@@ -45,13 +46,17 @@ import { PocketIDIcon } from "../icons/pocket-id";
 import { LocalAuthIcon } from "../icons/local-auth";
 import { OAuthIcon } from "../icons/oauth";
 
-function Avatar({ initial }: { initial: string }) {
+function Avatar({ initial, isOpen }: { initial: string; isOpen: boolean }) {
   return (
     <span className="group relative grid size-10 place-items-center rounded-full">
       <span className="absolute inset-0 overflow-hidden rounded-full bg-linear-to-b from-neutral-50 to-neutral-100 dark:from-neutral-700 dark:to-neutral-950 shadow-lg"></span>
-      <span className="relative text-sm font-semibold text-primary">
-        {initial}
-      </span>
+      {isOpen ? (
+        <X className="relative size-4 text-primary rotate-0 transition-transform duration-200 starting:rotate-45" />
+      ) : (
+        <span className="relative text-sm font-semibold text-primary rotate-0 transition-transform duration-200 starting:-rotate-45">
+          {initial}
+        </span>
+      )}
     </span>
   );
 }
@@ -80,6 +85,8 @@ export const QuickActions = () => {
   const searchParams = new URLSearchParams(search);
   const screenParams = useScreenParams(searchParams);
   const compiledParams = recompileScreenParams(screenParams);
+
+  const [isOpen, setIsOpen] = useState(false);
 
   const providerDetails = (():
     | { name: string; icon: React.ReactNode }
@@ -159,14 +166,14 @@ export const QuickActions = () => {
   ] as const;
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => setIsOpen(open)} open={isOpen}>
       <DropdownMenuTrigger asChild>
         <button
           aria-label={t("quickActionsTitle")}
           className="rounded-full transition-transform duration-200 will-change-transform hover:scale-105 hover:cursor-pointer focus:ring-0 focus:outline-3 focus:outline-ring/50"
         >
           {auth.authenticated ? (
-            <Avatar initial={initial!} />
+            <Avatar initial={initial!} isOpen={isOpen} />
           ) : (
             <span className="bg-card text-primary border-border size-10 flex items-center justify-center rounded-full border shadow-lg">
               <Settings className="size-4" />

--- a/frontend/src/components/quick-actions/quick-actions.tsx
+++ b/frontend/src/components/quick-actions/quick-actions.tsx
@@ -25,6 +25,7 @@ import {
   Palette,
   Settings,
   Sun,
+  UserRoundKey,
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -43,23 +44,8 @@ import { GithubIcon } from "../icons/github";
 import { TailscaleIcon } from "../icons/tailscale";
 import { MicrosoftIcon } from "../icons/microsoft";
 import { PocketIDIcon } from "../icons/pocket-id";
-import { LocalAuthIcon } from "../icons/local-auth";
 import { OAuthIcon } from "../icons/oauth";
-
-function Avatar({ initial, isOpen }: { initial: string; isOpen: boolean }) {
-  return (
-    <span className="group relative grid size-10 place-items-center rounded-full">
-      <span className="absolute inset-0 overflow-hidden rounded-full bg-linear-to-b from-neutral-50 to-neutral-100 dark:from-neutral-700 dark:to-neutral-950 shadow-lg"></span>
-      {isOpen ? (
-        <X className="relative size-4 text-primary rotate-0 transition-transform duration-200 starting:rotate-45" />
-      ) : (
-        <span className="relative text-sm font-semibold text-primary rotate-0 transition-transform duration-200 starting:-rotate-45">
-          {initial}
-        </span>
-      )}
-    </span>
-  );
-}
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 const iconStyles = "size-4";
 
@@ -102,7 +88,13 @@ export const QuickActions = () => {
             ? "quickActionsProviderLDAP"
             : "quickActionsProviderLocal",
         ),
-        icon: <LocalAuthIcon className={iconStyles} />,
+        icon: (
+          <UserRoundKey
+            strokeWidth={1.5}
+            size={16}
+            className="text-muted-foreground ml-0.5"
+          />
+        ),
       };
     }
 
@@ -173,10 +165,22 @@ export const QuickActions = () => {
           className="rounded-full transition-transform duration-200 will-change-transform hover:scale-105 hover:cursor-pointer focus:ring-0 focus:outline-3 focus:outline-ring/50"
         >
           {auth.authenticated ? (
-            <Avatar initial={initial!} isOpen={isOpen} />
+            <div className="size-10 flex justify-center items-center p-2 rounded-full bg-card border border-border">
+              {isOpen ? (
+                <X className="size-4 text-primary rotate-0 transition-transform duration-200 starting:rotate-45" />
+              ) : (
+                <span className="text-sm text-primary rotate-0 transition-transform duration-200 starting:-rotate-45">
+                  {initial}
+                </span>
+              )}
+            </div>
           ) : (
             <span className="bg-card text-primary border-border size-10 flex items-center justify-center rounded-full border shadow-lg">
-              <Settings className="size-4" />
+              <Settings
+                className={`size-4 transition-transform duration-200 ${
+                  isOpen ? "rotate-45" : "rotate-0"
+                }`}
+              />
             </span>
           )}
         </button>
@@ -190,21 +194,16 @@ export const QuickActions = () => {
         {auth.authenticated && (
           <>
             <DropdownMenuLabel className="flex items-center gap-3 p-2">
-              <div className="bg-foreground text-background flex size-9 shrink-0 items-center justify-center rounded-full text-sm font-medium">
-                {initial}
-              </div>
+              <Tooltip>
+                <TooltipTrigger className="size-9 rounded-full p-2 bg-muted border-border border flex items-center justify-center">
+                  {providerDetails!.icon}
+                </TooltipTrigger>
+                <TooltipContent>{providerDetails!.name}</TooltipContent>
+              </Tooltip>
               <div className="flex min-w-0 flex-col gap-1.5">
-                <div className="flex items-center gap-2">
-                  <span className="truncate text-sm font-medium leading-none">
-                    {auth.name}
-                  </span>
-                  {providerDetails && (
-                    <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1 rounded-lg bg-secondary px-2 py-1.25 text-[10px] font-medium leading-none [&_svg]:size-3">
-                      {providerDetails.icon}
-                      {providerDetails.name}
-                    </span>
-                  )}
-                </div>
+                <span className="truncate text-sm font-medium leading-none">
+                  {auth.name}
+                </span>
                 <span className="text-muted-foreground truncate text-xs leading-none">
                   {auth.email}
                 </span>
@@ -264,7 +263,7 @@ export const QuickActions = () => {
               onSelect={() => logoutMutation.mutate()}
               className="text-destructive"
             >
-              <DoorOpenIcon className="size-4" />
+              <DoorOpenIcon className="size-4 text-destructive" />
               {t("quickActionsLogout")}
             </DropdownMenuItem>
           </>

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -99,5 +99,8 @@
   "quickActionsThemeDark": "Dark",
   "quickActionsThemeSystem": "System",
   "quickActionsLogout": "Logout",
-  "quickActionsTitle": "Quick Actions"
+  "quickActionsTitle": "Quick Actions",
+  "quickActionsProviderLocal": "Local",
+  "quickActionsProviderLDAP": "LDAP",
+  "quickActionsProviderOAuth": "{{provider}} OAuth"
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -99,5 +99,8 @@
   "quickActionsThemeDark": "Dark",
   "quickActionsThemeSystem": "System",
   "quickActionsLogout": "Logout",
-  "quickActionsTitle": "Quick Actions"
+  "quickActionsTitle": "Quick Actions",
+  "quickActionsProviderLocal": "Local",
+  "quickActionsProviderLDAP": "LDAP",
+  "quickActionsProviderOAuth": "{{provider}} OAuth"
 }

--- a/frontend/src/pages/logout-page.tsx
+++ b/frontend/src/pages/logout-page.tsx
@@ -137,7 +137,7 @@ function LogoutLayout({ children, logoutMutation }: LogoutLayoutProps) {
       </CardHeader>
       <CardFooter>
         <Button
-          className="w-full"
+          className="w-full text-destructive"
           variant="outline"
           loading={logoutMutation.isPending}
           onClick={() => logoutMutation.mutate()}

--- a/internal/bootstrap/app_bootstrap.go
+++ b/internal/bootstrap/app_bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
@@ -131,6 +132,10 @@ func (app *BootstrapApp) Setup() error {
 	app.runtime.OAuthProviders = app.config.OAuth.Providers
 
 	for id, provider := range app.runtime.OAuthProviders {
+		if slices.Contains(model.ReservedProviderNames, id) {
+			return fmt.Errorf("provider id %s is reserved and cannot be used", id)
+		}
+
 		providerWhitelist, err := utils.GetStringList(provider.Whitelist, provider.WhitelistFile)
 		if err != nil {
 			return fmt.Errorf("failed to load oauth whitelist for provider %s: %w", id, err)

--- a/internal/model/constants.go
+++ b/internal/model/constants.go
@@ -17,6 +17,8 @@ var OverrideProviders = map[string]string{
 	"github": "GitHub",
 }
 
+var ReservedProviderNames = []string{"local", "ldap", "tailscale"}
+
 const SessionCookieName = "tinyauth-session"
 const CSRFCookieName = "tinyauth-csrf"
 const RedirectCookieName = "tinyauth-redirect"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Actions now shows the active login provider in the authenticated dropdown, with an icon and localized label (Local, LDAP, OAuth, and Tailscale).
* **Bug Fixes**
  * Prevented conflicts by rejecting custom OAuth providers that use reserved provider names.
* **UI / Style**
  * Updated the dropdown open/close visuals and adjusted logout text color styling for destructive actions.
* **Documentation**
  * Added/updated translation strings for provider labels used in Quick Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->