### PR TITLE
feat: improve binary size with build tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
           echo "VERSION=nightly" >> "$GITHUB_OUTPUT"
           echo "COMMIT_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_OUTPUT"
-          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@v1.100.0 -min -add acme,serve,netstack)
           export GIN_BUILD_TAGS=nomsgpack
           echo "BUILD_TAGS=$TAILSCALE_BUILD_TAGS,$GIN_BUILD_TAGS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,11 +35,17 @@ jobs:
       VERSION: ${{ steps.metadata.outputs.VERSION }}
       COMMIT_HASH: ${{ steps.metadata.outputs.COMMIT_HASH }}
       BUILD_TIMESTAMP: ${{ steps.metadata.outputs.BUILD_TIMESTAMP }}
+      BUILD_TAGS: ${{ steps.metadata.outputs.BUILD_TAGS }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: nightly
+
+      - name: Install go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "^1.26.4"
 
       - name: Generate metadata
         id: metadata
@@ -47,6 +53,9 @@ jobs:
           echo "VERSION=nightly" >> "$GITHUB_OUTPUT"
           echo "COMMIT_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_OUTPUT"
+          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+          export GIN_BUILD_TAGS=nomsgpack
+          echo "BUILD_TAGS=$TAILSCALE_BUILD_TAGS,$GIN_BUILD_TAGS" >> "$GITHUB_OUTPUT"
 
   binary-build:
     runs-on: ubuntu-latest
@@ -83,7 +92,11 @@ jobs:
       - name: Build
         run: |
           cp -r frontend/dist internal/assets/dist
-          go build -ldflags "-X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" -o tinyauth-amd64 ./cmd/tinyauth
+          go build -tags ${{ needs.generate-metadata.outputs.BUILD_TAGS }} \
+            -ldflags "-X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" \
+            -o tinyauth-amd64 ./cmd/tinyauth
         env:
           CGO_ENABLED: 0
 
@@ -128,7 +141,11 @@ jobs:
       - name: Build
         run: |
           cp -r frontend/dist internal/assets/dist
-          go build -ldflags "-X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" -o tinyauth-arm64 ./cmd/tinyauth
+          go build -tags ${{ needs.generate-metadata.outputs.BUILD_TAGS }} \
+            -ldflags "-X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" \
+            -o tinyauth-arm64 ./cmd/tinyauth
         env:
           CGO_ENABLED: 0
 
@@ -180,6 +197,7 @@ jobs:
             VERSION=${{ needs.generate-metadata.outputs.VERSION }}
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -190,7 +208,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-linux-amd64
+          name: digests-alpine-linux-amd64
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -239,6 +257,7 @@ jobs:
             VERSION=${{ needs.generate-metadata.outputs.VERSION }}
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -296,6 +315,7 @@ jobs:
             VERSION=${{ needs.generate-metadata.outputs.VERSION }}
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -306,7 +326,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-linux-arm64
+          name: digests-alpine-linux-arm64
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -355,6 +375,7 @@ jobs:
             VERSION=${{ needs.generate-metadata.outputs.VERSION }}
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -380,7 +401,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          pattern: digests-alpine-*
           merge-multiple: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,15 @@ jobs:
       VERSION: ${{ steps.metadata.outputs.VERSION }}
       COMMIT_HASH: ${{ steps.metadata.outputs.COMMIT_HASH }}
       BUILD_TIMESTAMP: ${{ steps.metadata.outputs.BUILD_TIMESTAMP }}
+      BUILD_TAGS: ${{ steps.metadata.outputs.BUILD_TAGS }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "^1.26.4"
 
       - name: Generate metadata
         id: metadata
@@ -26,6 +32,9 @@ jobs:
           echo "VERSION=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           echo "COMMIT_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_OUTPUT"
+          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+          export GIN_BUILD_TAGS=nomsgpack
+          echo "BUILD_TAGS=$TAILSCALE_BUILD_TAGS,$GIN_BUILD_TAGS" >> "$GITHUB_OUTPUT"
 
   binary-build:
     runs-on: ubuntu-latest
@@ -59,7 +68,11 @@ jobs:
       - name: Build
         run: |
           cp -r frontend/dist internal/assets/dist
-          go build -ldflags "-s -w -X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" -o tinyauth-amd64 ./cmd/tinyauth
+          go build -tags ${{ needs.generate-metadata.outputs.BUILD_TAGS }} \
+            -ldflags "-s -w -X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" \
+            -o tinyauth-amd64 ./cmd/tinyauth
         env:
           CGO_ENABLED: 0
 
@@ -101,7 +114,11 @@ jobs:
       - name: Build
         run: |
           cp -r frontend/dist internal/assets/dist
-          go build -ldflags "-s -w -X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" -o tinyauth-arm64 ./cmd/tinyauth
+          go build -tags ${{ needs.generate-metadata.outputs.BUILD_TAGS }} \
+            -ldflags "-s -w -X github.com/tinyauthapp/tinyauth/internal/model.Version=${{ needs.generate-metadata.outputs.VERSION }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${{ needs.generate-metadata.outputs.COMMIT_HASH }} \
+            -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}" \
+            -o tinyauth-arm64 ./cmd/tinyauth
         env:
           CGO_ENABLED: 0
 
@@ -151,6 +168,7 @@ jobs:
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
             LDFLAGS=-s -w
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -161,7 +179,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-linux-amd64
+          name: digests-alpine-linux-amd64
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -208,6 +226,7 @@ jobs:
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
             LDFLAGS=-s -w
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -263,6 +282,7 @@ jobs:
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
             LDFLAGS=-s -w
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -273,7 +293,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-linux-arm64
+          name: digests-alpine-linux-arm64
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -320,6 +340,7 @@ jobs:
             COMMIT_HASH=${{ needs.generate-metadata.outputs.COMMIT_HASH }}
             BUILD_TIMESTAMP=${{ needs.generate-metadata.outputs.BUILD_TIMESTAMP }}
             LDFLAGS=-s -w
+            BUILD_TAGS=${{ needs.generate-metadata.outputs.BUILD_TAGS }}
 
       - name: Export digest
         run: |
@@ -345,7 +366,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          pattern: digests-alpine-*
           merge-multiple: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,13 @@ jobs:
 
       - name: Generate metadata
         id: metadata
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "VERSION=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$REF_NAME" >> "$GITHUB_OUTPUT"
           echo "COMMIT_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')" >> "$GITHUB_OUTPUT"
-          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+          export TAILSCALE_BUILD_TAGS=$(go run tailscale.com/cmd/featuretags@v1.100.0 -min -add acme,serve,netstack)
           export GIN_BUILD_TAGS=nomsgpack
           echo "BUILD_TAGS=$TAILSCALE_BUILD_TAGS,$GIN_BUILD_TAGS" >> "$GITHUB_OUTPUT"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY ./cmd ./cmd
 COPY ./internal ./internal
 COPY --from=frontend-builder /frontend/dist ./internal/assets/dist
 
-RUN CGO_ENABLED=0 go build -tags ${BUILD_TAGS} -ldflags "${LDFLAGS} \
+RUN CGO_ENABLED=0 go build -tags "${BUILD_TAGS}" -ldflags "${LDFLAGS} \
     -X github.com/tinyauthapp/tinyauth/internal/model.Version=${VERSION} \
     -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${COMMIT_HASH} \
     -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ARG VERSION
 ARG COMMIT_HASH
 ARG BUILD_TIMESTAMP
 ARG LDFLAGS
+ARG BUILD_TAGS
 
 WORKDIR /tinyauth
 
@@ -40,10 +41,11 @@ COPY ./cmd ./cmd
 COPY ./internal ./internal
 COPY --from=frontend-builder /frontend/dist ./internal/assets/dist
 
-RUN CGO_ENABLED=0 go build -ldflags "${LDFLAGS} \
+RUN CGO_ENABLED=0 go build -tags ${BUILD_TAGS} -ldflags "${LDFLAGS} \
     -X github.com/tinyauthapp/tinyauth/internal/model.Version=${VERSION} \
     -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${COMMIT_HASH} \
-    -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" ./cmd/tinyauth
+    -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" \
+    -o tinyauth ./cmd/tinyauth
 
 # Runner
 FROM alpine:3.24 AS runner

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -28,6 +28,7 @@ ARG VERSION
 ARG COMMIT_HASH
 ARG BUILD_TIMESTAMP
 ARG LDFLAGS
+ARG BUILD_TAGS
 
 WORKDIR /tinyauth
 
@@ -36,14 +37,15 @@ COPY go.sum ./
 
 RUN go mod download
 
-COPY ./cmd ./cmd
+COPY ./cmd ./cmd/
 COPY ./internal ./internal
 COPY --from=frontend-builder /frontend/dist ./internal/assets/dist
 
-RUN CGO_ENABLED=0 go build -ldflags "${LDFLAGS} \
+RUN CGO_ENABLED=0 go build -tags ${BUILD_TAGS} -ldflags "${LDFLAGS} \
     -X github.com/tinyauthapp/tinyauth/internal/model.Version=${VERSION} \
     -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${COMMIT_HASH} \
-    -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" ./cmd/tinyauth
+    -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" \
+    -o tinyauth ./cmd/tinyauth
 
 # Make the data directory with a non-root user
 RUN addgroup tinyauth && adduser -DH tinyauth -G tinyauth

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -41,7 +41,7 @@ COPY ./cmd ./cmd/
 COPY ./internal ./internal
 COPY --from=frontend-builder /frontend/dist ./internal/assets/dist
 
-RUN CGO_ENABLED=0 go build -tags ${BUILD_TAGS} -ldflags "${LDFLAGS} \
+RUN CGO_ENABLED=0 go build -tags "${BUILD_TAGS}" -ldflags "${LDFLAGS} \
     -X github.com/tinyauthapp/tinyauth/internal/model.Version=${VERSION} \
     -X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${COMMIT_HASH} \
     -X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" \

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,18 @@ generate:
 
 # Docker image
 docker:
-	docker buildx build -t tinyauthapp/tinyauth:dev --build-arg=VERSION=$(TAG_NAME) --build-arg=COMMIT_HASH=$(COMMIT_HASH) --build-arg=BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) -f Dockerfile .
+	docker buildx build -t tinyauthapp/tinyauth:dev \
+		--build-arg=VERSION=$(TAG_NAME) \
+		--build-arg=COMMIT_HASH=$(COMMIT_HASH) \
+		--build-arg=BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+		--build-arg=BUILD_TAGS=$(BUILD_TAGS) \
+		-f Dockerfile .
 
 # Docker image distroless
 docker-distroless:
-	docker buildx build -t tinyauthapp/tinyauth:dev-distroless --build-arg=VERSION=$(TAG_NAME) --build-arg=COMMIT_HASH=$(COMMIT_HASH) --build-arg=BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) -f Dockerfile.distroless .
+	docker buildx build -t tinyauthapp/tinyauth:dev-distroless \
+		--build-arg=VERSION=$(TAG_NAME) \
+		--build-arg=COMMIT_HASH=$(COMMIT_HASH) \
+		--build-arg=BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+		--build-arg=BUILD_TAGS=$(BUILD_TAGS) \
+		-f Dockerfile.distroless .

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ BUILD_TIMESTAMP := $(shell date '+%Y-%m-%dT%H:%M:%S')
 BIN_NAME := tinyauth-$(GOARCH)
 LDFLAGS := -s -w
 # We don't want all of the tailscale feature-set
-TAILSCALE_BUILD_TAGS := $(shell go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+TAILSCALE_BUILD_TAGS = $(shell go run tailscale.com/cmd/featuretags@v1.100.0 -min -add acme,serve,netstack)
 # Whatever 6MB serialization lib Gin is using
 GIN_BUILD_TAGS := nomsgpack
-BUILD_TAGS := $(GIN_BUILD_TAGS),$(TAILSCALE_BUILD_TAGS)
+BUILD_TAGS = $(GIN_BUILD_TAGS),$(TAILSCALE_BUILD_TAGS)
 
 # Development vars
 DEV_COMPOSE := $(shell test -f "docker-compose.test.yml" && echo "docker-compose.test.yml" || echo "docker-compose.dev.yml" )

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ COMMIT_HASH := $(shell git rev-parse HEAD)
 BUILD_TIMESTAMP := $(shell date '+%Y-%m-%dT%H:%M:%S')
 BIN_NAME := tinyauth-$(GOARCH)
 LDFLAGS := -s -w
+# We don't want all of the tailscale feature-set
+TAILSCALE_BUILD_TAGS := $(shell go run tailscale.com/cmd/featuretags@latest -min -add acme,serve,netstack)
+# Whatever 6MB serialization lib Gin is using
+GIN_BUILD_TAGS := nomsgpack
+BUILD_TAGS := $(GIN_BUILD_TAGS),$(TAILSCALE_BUILD_TAGS)
 
 # Development vars
 DEV_COMPOSE := $(shell test -f "docker-compose.test.yml" && echo "docker-compose.test.yml" || echo "docker-compose.dev.yml" )
@@ -39,7 +44,7 @@ webui: clean-webui
 
 # Build the binary
 binary: webui
-	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags "${LDFLAGS} \
+	CGO_ENABLED=$(CGO_ENABLED) go build -tags "${BUILD_TAGS}" -ldflags "${LDFLAGS} \
 	-X github.com/tinyauthapp/tinyauth/internal/model.Version=${TAG_NAME} \
 	-X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${COMMIT_HASH} \
 	-X github.com/tinyauthapp/tinyauth/internal/model.BuildTimestamp=${BUILD_TIMESTAMP}" \

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	charm.land/huh/v2 v2.0.3
+	charm.land/lipgloss/v2 v2.0.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/gin-gonic/gin v1.12.0
@@ -25,6 +26,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/tools v0.47.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
 	modernc.org/sqlite v1.53.0
@@ -34,7 +36,6 @@ require (
 require (
 	charm.land/bubbles/v2 v2.0.0 // indirect
 	charm.land/bubbletea/v2 v2.0.2 // indirect
-	charm.land/lipgloss/v2 v2.0.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect
@@ -169,7 +170,6 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	gvisor.dev/gvisor v0.0.0-20260224225140-573d5e7127a8 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -739,7 +739,7 @@ func (controller *OIDCController) resolveRequestObject(c *gin.Context) (*service
 func (controller *OIDCController) resolveNormalParams(c *gin.Context) (*service.AuthorizeRequest, error) {
 	var req service.AuthorizeRequest
 
-	bind := binding.Query
+	var bind binding.Binding = binding.Query
 
 	if c.Request.Method == http.MethodPost {
 		bind = binding.Form


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release/nightly pipelines now generate a shared `BUILD_TAGS` set and apply it to Go binary builds and Docker image builds.
  * Docker builds receive the same feature tags via build arguments for both amd64 and arm64 (including distroless and alpine flows).
* **Bug Fixes**
  * Renamed Alpine digest artifacts and tightened the image-merge matching to ensure the correct digests are merged.
* **Chores**
  * Makefile now derives tags dynamically for local builds; minor dependency and formatting updates were applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->