### PR TITLE
feat: try anonymous bind when bind credentials are empty

### DIFF
--- a/internal/service/ldap_service.go
+++ b/internal/service/ldap_service.go
@@ -246,6 +246,12 @@ func (ldap *LdapService) BindService(rebind bool) error {
 	if ldap.cert != nil {
 		return ldap.conn.ExternalBind()
 	}
+
+	// attempt unauthenticated/anonymous bind if both BindDN and bindpw are unset
+	if ldap.config.LDAP.BindDN == "" && ldap.bindPw == "" {
+		return ldap.conn.UnauthenticatedBind("")
+	}
+
 	return ldap.conn.Bind(ldap.config.LDAP.BindDN, ldap.bindPw)
 }
 


### PR DESCRIPTION
Allow anonymous bind (i.e. unauthenticated) when the bind username and password aren't provided, to support LDAP servers which allow anonymous access, e.g. for directory lookups. This avoids a fatal error which currently occurs when attempting an anonymous bind: 

```
WRN internal/bootstrap/service_bootstrap.go:35 > Failed to setup LDAP service, starting without it
error="failed to connect to LDAP server: LDAP Result Code 206 \"Empty password not allowed by the
client\": ldap: empty password not allowed by the client" log_stream=app
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LDAP sign-in behavior when no bind credentials are provided, allowing anonymous authentication in supported environments.
  * Existing certificate-based LDAP connections continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->