### PR TITLE
feat: add SkipAuthorization option for OIDC clients

### DIFF
--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -206,37 +206,6 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 
 	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
 
-	if client.SkipAuthorization && userContext != nil && userContext.Authenticated {
-		controller.oidc.DeleteAuthorizeRequestTicket(ticket)
-		sub := controller.oidc.CreateSub(*userContext, req.ClientID)
-		if err := controller.oidc.DeleteOldSession(c, sub); err != nil {
-			controller.authorizeError(c, authorizeErrorParams{
-				err:           err,
-				reason:        "Failed to delete old sessions",
-				reasonPublic:  "Failed to delete old sessions",
-				callback:      req.RedirectURI,
-				callbackError: "server_error",
-				state:         req.State,
-			})
-			return
-		}
-		code := controller.oidc.CreateCode(*req, *userContext)
-		queries, err := query.Values(AuthorizeCallback{Code: code, State: req.State})
-		if err != nil {
-			controller.authorizeError(c, authorizeErrorParams{
-				err:           err,
-				reason:        "Failed to build query",
-				reasonPublic:  "Failed to build query",
-				callback:      req.RedirectURI,
-				callbackError: "server_error",
-				state:         req.State,
-			})
-			return
-		}
-		c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", req.RedirectURI, queries.Encode()))
-		return
-	}
-
 	values := AuthorizeScreenParams{
 		LoginFor:   FrontendLoginForOIDC,
 		OIDCTicket: ticket,
@@ -270,6 +239,37 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 				values.OIDCPrompt = service.OIDCPromptLogin
 			}
 		}
+	}
+
+	if client.SkipAuthorization && values.OIDCPrompt != service.OIDCPromptLogin && userContext != nil && userContext.Authenticated {
+		controller.oidc.DeleteAuthorizeRequestTicket(ticket)
+		sub := controller.oidc.CreateSub(*userContext, req.ClientID)
+		if err := controller.oidc.DeleteOldSession(c, sub); err != nil {
+			controller.authorizeError(c, authorizeErrorParams{
+				err:           err,
+				reason:        "Failed to delete old sessions",
+				reasonPublic:  "Failed to delete old sessions",
+				callback:      req.RedirectURI,
+				callbackError: "server_error",
+				state:         req.State,
+			})
+			return
+		}
+		code := controller.oidc.CreateCode(*req, *userContext)
+		queries, err := query.Values(AuthorizeCallback{Code: code, State: req.State})
+		if err != nil {
+			controller.authorizeError(c, authorizeErrorParams{
+				err:           err,
+				reason:        "Failed to build query",
+				reasonPublic:  "Failed to build query",
+				callback:      req.RedirectURI,
+				callbackError: "server_error",
+				state:         req.State,
+			})
+			return
+		}
+		c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", req.RedirectURI, queries.Encode()))
+		return
 	}
 
 	queries, err := query.Values(values)

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -256,19 +257,23 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 			return
 		}
 		code := controller.oidc.CreateCode(*req, *userContext)
-		queries, err := query.Values(AuthorizeCallback{Code: code, State: req.State})
+		redirectURL, err := url.Parse(req.RedirectURI)
 		if err != nil {
 			controller.authorizeError(c, authorizeErrorParams{
 				err:           err,
-				reason:        "Failed to build query",
-				reasonPublic:  "Failed to build query",
+				reason:        "Failed to build callback URL",
+				reasonPublic:  "Failed to build callback URL",
 				callback:      req.RedirectURI,
 				callbackError: "server_error",
 				state:         req.State,
 			})
 			return
 		}
-		c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", req.RedirectURI, queries.Encode()))
+		redirectQueries := redirectURL.Query()
+		redirectQueries.Set("code", code)
+		redirectQueries.Set("state", req.State)
+		redirectURL.RawQuery = redirectQueries.Encode()
+		c.Redirect(http.StatusFound, redirectURL.String())
 		return
 	}
 

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -206,6 +206,37 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 
 	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
 
+	if client.SkipAuthorization && userContext != nil && userContext.Authenticated {
+		controller.oidc.DeleteAuthorizeRequestTicket(ticket)
+		sub := controller.oidc.CreateSub(*userContext, req.ClientID)
+		if err := controller.oidc.DeleteOldSession(c, sub); err != nil {
+			controller.authorizeError(c, authorizeErrorParams{
+				err:           err,
+				reason:        "Failed to delete old sessions",
+				reasonPublic:  "Failed to delete old sessions",
+				callback:      req.RedirectURI,
+				callbackError: "server_error",
+				state:         req.State,
+			})
+			return
+		}
+		code := controller.oidc.CreateCode(*req, *userContext)
+		queries, err := query.Values(AuthorizeCallback{Code: code, State: req.State})
+		if err != nil {
+			controller.authorizeError(c, authorizeErrorParams{
+				err:           err,
+				reason:        "Failed to build query",
+				reasonPublic:  "Failed to build query",
+				callback:      req.RedirectURI,
+				callbackError: "server_error",
+				state:         req.State,
+			})
+			return
+		}
+		c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", req.RedirectURI, queries.Encode()))
+		return
+	}
+
 	values := AuthorizeScreenParams{
 		LoginFor:   FrontendLoginForOIDC,
 		OIDCTicket: ticket,

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -205,20 +205,7 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		return
 	}
 
-	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
-
-	values := AuthorizeScreenParams{
-		LoginFor:   FrontendLoginForOIDC,
-		OIDCTicket: ticket,
-		OIDCScope:  req.Scope,
-		OIDCName:   client.Name,
-	}
-
-	if slices.Contains(prompts, service.OIDCPromptLogin) {
-		values.OIDCPrompt = service.OIDCPromptLogin
-	} else if slices.Contains(prompts, service.OIDCPromptNone) {
-		values.OIDCPrompt = service.OIDCPromptNone
-	}
+	forceLogin := slices.Contains(prompts, service.OIDCPromptLogin)
 
 	if req.MaxAge != "" && userContext != nil {
 		maxAge, err := strconv.Atoi(req.MaxAge)
@@ -237,12 +224,14 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		if userContext.Authenticated {
 			authTime := time.Unix(userContext.AuthTime, 0)
 			if authTime.Add(time.Duration(maxAge) * time.Second).Before(time.Now()) {
-				values.OIDCPrompt = service.OIDCPromptLogin
+				forceLogin = true
 			}
 		}
 	}
 
-	if client.SkipAuthorization && values.OIDCPrompt != service.OIDCPromptLogin && userContext != nil && userContext.Authenticated {
+	ticket := controller.oidc.CreateAuthorizeRequestTicket(*req)
+
+	if client.SkipAuthorization && userContext != nil && userContext.Authenticated && !forceLogin {
 		controller.oidc.DeleteAuthorizeRequestTicket(ticket)
 		sub := controller.oidc.CreateSub(*userContext, req.ClientID)
 		if err := controller.oidc.DeleteOldSession(c, sub); err != nil {
@@ -275,6 +264,19 @@ func (controller *OIDCController) authorize(c *gin.Context) {
 		redirectURL.RawQuery = redirectQueries.Encode()
 		c.Redirect(http.StatusFound, redirectURL.String())
 		return
+	}
+
+	values := AuthorizeScreenParams{
+		LoginFor:   FrontendLoginForOIDC,
+		OIDCTicket: ticket,
+		OIDCScope:  req.Scope,
+		OIDCName:   client.Name,
+	}
+
+	if forceLogin {
+		values.OIDCPrompt = service.OIDCPromptLogin
+	} else if slices.Contains(prompts, service.OIDCPromptNone) {
+		values.OIDCPrompt = service.OIDCPromptNone
 	}
 
 	queries, err := query.Values(values)

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -271,8 +271,9 @@ type OIDCClientConfig struct {
 	ClientID            string   `description:"OIDC client ID." yaml:"clientId,omitempty"`
 	ClientSecret        string   `description:"OIDC client secret." yaml:"clientSecret,omitempty"`
 	ClientSecretFile    string   `description:"Path to the file containing the OIDC client secret." yaml:"clientSecretFile,omitempty"`
-	TrustedRedirectURIs []string `description:"List of trusted redirect URIs." yaml:"trustedRedirectUris,omitempty"`
-	Name                string   `description:"Client name in UI." yaml:"name,omitempty"`
+	TrustedRedirectURIs  []string `description:"List of trusted redirect URIs." yaml:"trustedRedirectUris,omitempty"`
+	Name                 string   `description:"Client name in UI." yaml:"name,omitempty"`
+	SkipAuthorization    bool     `description:"Skip the authorization consent screen for this client." yaml:"skipAuthorization,omitempty"`
 }
 
 type ACLsConfig struct {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -271,9 +271,9 @@ type OIDCClientConfig struct {
 	ClientID            string   `description:"OIDC client ID." yaml:"clientId,omitempty"`
 	ClientSecret        string   `description:"OIDC client secret." yaml:"clientSecret,omitempty"`
 	ClientSecretFile    string   `description:"Path to the file containing the OIDC client secret." yaml:"clientSecretFile,omitempty"`
-	TrustedRedirectURIs  []string `description:"List of trusted redirect URIs." yaml:"trustedRedirectUris,omitempty"`
-	Name                 string   `description:"Client name in UI." yaml:"name,omitempty"`
-	SkipAuthorization    bool     `description:"Skip the authorization consent screen for this client." yaml:"skipAuthorization,omitempty"`
+	TrustedRedirectURIs []string `description:"List of trusted redirect URIs." yaml:"trustedRedirectUris,omitempty"`
+	Name                string   `description:"Client name in UI." yaml:"name,omitempty"`
+	SkipAuthorization   bool     `description:"Skip the authorization consent screen for this client." yaml:"skipAuthorization,omitempty"`
 }
 
 type ACLsConfig struct {


### PR DESCRIPTION
## Problem

When a user logs in via OIDC, they are always shown a consent screen asking them to authorize the client. For trusted, self-hosted clients this is unnecessary friction — the user is effectively asked "do you trust your own app?" every time their session expires.

Fixes #878

## Solution

Add a `skipAuthorization` boolean field to `OIDCClientConfig`. When set to `true` and the user is already authenticated, the authorize endpoint bypasses the consent screen and immediately issues the authorization code and redirects back to the client.

## Configuration

**Environment variable:**
```
TINYAUTH_OIDC_CLIENTS_<NAME>_SKIPAUTHORIZATION=true
```

**YAML:**
```yaml
oidc:
  clients:
    myapp:
      skipAuthorization: true
```

## Notes

- Only skips the consent screen if the user is already authenticated. If not authenticated, the normal login + consent flow applies.
- The ticket is cleaned up immediately (same as the normal post-consent path).
- Old sessions are deleted before issuing the code (same behaviour as `authorizeComplete`).

## AI Disclosure

This pull request was developed with AI assistance (Claude). The implementation has been reviewed and is fully understood by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `skipAuthorization` option for OIDC clients to bypass the consent/authorization screen when the user is already signed in and no login is forced.
  * For supported cases, authorization now completes immediately and redirects back to the requesting app with the authorization response (`code` and `state`).

* **Behavior Updates**
  * When `max_age` indicates the existing session is too old, login may be required even if `skipAuthorization` is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->