### PR TITLE
feat: support proxy environment variables for OAuth requests

### DIFF
--- a/internal/service/oauth_service.go
+++ b/internal/service/oauth_service.go
@@ -24,6 +24,7 @@ func NewOAuthService(config model.OAuthServiceConfig, id string, ctx context.Con
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.Insecure,
 				MinVersion:         tls.VersionTLS12,


### PR DESCRIPTION
The OAuth service currently uses a custom `http.Transport` to configure TLS.

This change configures that transport to use also `http.ProxyFromEnvironment` to enable `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` for token exchange and userinfo requests. The existing TLS configuration and other transport behavior remain unchanged.

Closes #998

### Verification

`make webui test` and manual test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth network requests now respect proxy settings provided through the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->