### PR TITLE
feat: allow existing query params in oidc redirect uri

### DIFF
--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -343,27 +344,30 @@ func (controller *OIDCController) authorizeComplete(c *gin.Context) {
 	// Create the authorization code
 	code := controller.oidc.CreateCode(*authorizeReq, *userContext)
 
-	queries, err := query.Values(AuthorizeCallback{
-		Code:  code,
-		State: authorizeReq.State,
-	})
+	cu, err := url.Parse(authorizeReq.RedirectURI)
 
 	if err != nil {
 		controller.authorizeError(c, authorizeErrorParams{
 			err:           err,
-			reason:        "Failed to build query",
-			reasonPublic:  "Failed to build query",
+			reason:        "Failed to parse redirect URI",
+			reasonPublic:  "Failed to parse redirect URI",
 			callback:      authorizeReq.RedirectURI,
 			callbackError: "server_error",
 			state:         authorizeReq.State,
 			json:          true,
 		})
-		return
 	}
+
+	q := cu.Query()
+
+	q.Set("code", code)
+	q.Set("state", authorizeReq.State)
+
+	cu.RawQuery = q.Encode()
 
 	c.JSON(200, gin.H{
 		"status":       200,
-		"redirect_uri": fmt.Sprintf("%s?%s", authorizeReq.RedirectURI, queries.Encode()),
+		"redirect_uri": cu.String(),
 	})
 }
 
@@ -639,37 +643,37 @@ func (controller *OIDCController) authorizeError(c *gin.Context, params authoriz
 	controller.log.App.Error().Err(params.err).Str("reason", params.reason).Msg("Authorization error")
 
 	if params.callback != "" {
-		errorQueries := CallbackError{
-			Error: params.callbackError,
-		}
-
-		if params.reasonPublic != "" {
-			errorQueries.ErrorDescription = params.reasonPublic
-		}
-
-		if params.state != "" {
-			errorQueries.State = params.state
-		}
-
-		queries, err := query.Values(errorQueries)
+		cu, err := url.Parse(params.callback)
 
 		if err != nil {
-			controller.log.App.Error().Err(err).Msg("Failed to build callback error query")
+			controller.log.App.Error().Err(err).Msg("Failed to parse callback URL")
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
 
-		redirectUrl := fmt.Sprintf("%s?%s", params.callback, queries.Encode())
+		q := cu.Query()
+
+		q.Set("error", params.callbackError)
+
+		if params.reasonPublic != "" {
+			q.Set("error_description", params.reasonPublic)
+		}
+
+		if params.state != "" {
+			q.Set("state", params.state)
+		}
+
+		cu.RawQuery = q.Encode()
 
 		if params.json {
 			c.JSON(200, gin.H{
 				"status":       200,
-				"redirect_uri": redirectUrl,
+				"redirect_uri": cu.String(),
 			})
 			return
 		}
 
-		c.Redirect(http.StatusFound, redirectUrl)
+		c.Redirect(http.StatusFound, cu.String())
 		return
 	}
 

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -348,13 +348,10 @@ func (controller *OIDCController) authorizeComplete(c *gin.Context) {
 
 	if err != nil {
 		controller.authorizeError(c, authorizeErrorParams{
-			err:           err,
-			reason:        "Failed to parse redirect URI",
-			reasonPublic:  "Failed to parse redirect URI",
-			callback:      authorizeReq.RedirectURI,
-			callbackError: "server_error",
-			state:         authorizeReq.State,
-			json:          true,
+			err:          err,
+			reason:       "Failed to parse redirect URI",
+			reasonPublic: "Failed to parse redirect URI",
+			json:         true,
 		})
 		return
 	}

--- a/internal/controller/oidc_controller.go
+++ b/internal/controller/oidc_controller.go
@@ -356,12 +356,16 @@ func (controller *OIDCController) authorizeComplete(c *gin.Context) {
 			state:         authorizeReq.State,
 			json:          true,
 		})
+		return
 	}
 
 	q := cu.Query()
 
 	q.Set("code", code)
-	q.Set("state", authorizeReq.State)
+
+	if authorizeReq.State != "" {
+		q.Set("state", authorizeReq.State)
+	}
 
 	cu.RawQuery = q.Encode()
 


### PR DESCRIPTION
Fixes #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC authorization redirect handling by preserving existing callback query parameters while adding the authorization code, and state when present.
  * Ensured OIDC error responses correctly include error details and optionally state using the callback URL query when applicable.
  * Added clearer failure behavior when redirect/callback URLs can’t be parsed, including structured JSON error responses and aborting on callback URL parse failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->