### PR TITLE
fix: use constant time in user checks

### DIFF
--- a/internal/controller/proxy_controller_test.go
+++ b/internal/controller/proxy_controller_test.go
@@ -708,7 +708,7 @@ func TestProxyController(t *testing.T) {
 		Log: log,
 	})
 
-	authService := service.NewAuthService(service.AuthServiceInput{
+	authService, err := service.NewAuthService(service.AuthServiceInput{
 		Log:          log,
 		Config:       &cfg,
 		Runtime:      &runtime,
@@ -720,6 +720,8 @@ func TestProxyController(t *testing.T) {
 		Tailscale:    nil,
 		PolicyEngine: policyEngine,
 	})
+
+	require.NoError(t, err)
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -90,6 +90,7 @@ func (controller *UserController) loginHandler(c *gin.Context) {
 
 	if err != nil {
 		if errors.Is(err, service.ErrUserNotFound) {
+			controller.auth.DummyPasswordCheck()
 			controller.log.App.Warn().Str("username", req.Username).Msg("User not found during login attempt")
 			controller.auth.RecordLoginAttempt(req.Username, false)
 			controller.log.AuditLoginFailure(req.Username, "unknown", c.ClientIP(), "user not found")

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -90,7 +90,7 @@ func (controller *UserController) loginHandler(c *gin.Context) {
 
 	if err != nil {
 		if errors.Is(err, service.ErrUserNotFound) {
-			controller.auth.DummyPasswordCheck()
+			controller.auth.DummyPasswordCheck(req.Password)
 			controller.log.App.Warn().Str("username", req.Username).Msg("User not found during login attempt")
 			controller.auth.RecordLoginAttempt(req.Username, false)
 			controller.log.AuditLoginFailure(req.Username, "unknown", c.ClientIP(), "user not found")

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -542,7 +542,8 @@ func TestUserController(t *testing.T) {
 		Runtime: &runtime,
 		Ctx:     ctx,
 	})
-	authService := service.NewAuthService(service.AuthServiceInput{
+
+	authService, err := service.NewAuthService(service.AuthServiceInput{
 		Log:          log,
 		Config:       &cfg,
 		Runtime:      &runtime,
@@ -554,6 +555,8 @@ func TestUserController(t *testing.T) {
 		Tailscale:    nil,
 		PolicyEngine: policyEngine,
 	})
+
+	require.NoError(t, err)
 
 	beforeEach := func() {
 		// Clear failed login attempts before each test

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -244,6 +244,7 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 	search, err := m.auth.SearchUser(username)
 
 	if err != nil {
+		m.auth.DummyPasswordCheck()
 		return nil, nil, fmt.Errorf("error searching for user: %w", err)
 	}
 

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -244,7 +245,9 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 	search, err := m.auth.SearchUser(username)
 
 	if err != nil {
-		m.auth.DummyPasswordCheck()
+		if errors.Is(err, service.ErrUserNotFound) {
+			m.auth.DummyPasswordCheck()
+		}
 		return nil, nil, fmt.Errorf("error searching for user: %w", err)
 	}
 

--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -246,7 +246,7 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 
 	if err != nil {
 		if errors.Is(err, service.ErrUserNotFound) {
-			m.auth.DummyPasswordCheck()
+			m.auth.DummyPasswordCheck(password)
 		}
 		return nil, nil, fmt.Errorf("error searching for user: %w", err)
 	}

--- a/internal/middleware/context_middleware_test.go
+++ b/internal/middleware/context_middleware_test.go
@@ -264,7 +264,8 @@ func TestContextMiddleware(t *testing.T) {
 		Runtime: &runtime,
 		Ctx:     ctx,
 	})
-	authService := service.NewAuthService(service.AuthServiceInput{
+
+	authService, err := service.NewAuthService(service.AuthServiceInput{
 		Log:          log,
 		Config:       &cfg,
 		Runtime:      &runtime,
@@ -276,6 +277,8 @@ func TestContextMiddleware(t *testing.T) {
 		Tailscale:    nil,
 		PolicyEngine: policyEngine,
 	})
+
+	require.NoError(t, err)
 
 	contextMiddleware := NewContextMiddleware(ContextMiddlewareInput{
 		Log:              log,

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -69,6 +69,8 @@ type AuthService struct {
 	tailscale    *TailscaleService
 	policyEngine *PolicyEngine
 
+	dummyHash string
+
 	lockdown struct {
 		active     bool
 		until      time.Time
@@ -101,7 +103,7 @@ type AuthServiceInput struct {
 	PolicyEngine *PolicyEngine
 }
 
-func NewAuthService(i AuthServiceInput) *AuthService {
+func NewAuthService(i AuthServiceInput) (*AuthService, error) {
 	service := &AuthService{
 		log:          i.Log,
 		runtime:      i.Runtime,
@@ -122,6 +124,15 @@ func NewAuthService(i AuthServiceInput) *AuthService {
 	if !service.config.Auth.LockdownEnabled {
 		loginCacheSize = service.maxLoginLimits
 	}
+
+	// dummy hash
+	dummyHash, err := bcrypt.GenerateFromPassword([]byte(utils.GenerateString(8)), bcrypt.DefaultCost)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate dummy hash: %w", err)
+	}
+
+	service.dummyHash = string(dummyHash)
 
 	// caches setup
 	oauthCache := NewCacheStore[OAuthPendingSession](256)
@@ -148,7 +159,12 @@ func NewAuthService(i AuthServiceInput) *AuthService {
 		}
 	}, ding.RingMinor)
 
-	return service
+	return service, nil
+}
+
+func (auth *AuthService) DummyPasswordCheck() {
+	random := utils.GenerateString(8)
+	bcrypt.CompareHashAndPassword([]byte(auth.dummyHash), []byte(random))
 }
 
 func (auth *AuthService) SearchUser(username string) (*model.UserSearch, error) {

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -162,9 +162,8 @@ func NewAuthService(i AuthServiceInput) (*AuthService, error) {
 	return service, nil
 }
 
-func (auth *AuthService) DummyPasswordCheck() {
-	random := utils.GenerateString(8)
-	bcrypt.CompareHashAndPassword([]byte(auth.dummyHash), []byte(random))
+func (auth *AuthService) DummyPasswordCheck(password string) {
+	bcrypt.CompareHashAndPassword([]byte(auth.dummyHash), []byte(password))
 }
 
 func (auth *AuthService) SearchUser(username string) (*model.UserSearch, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in handling for unknown usernames by performing a consistent dummy password-check before returning HTTP 401.
  * Aligned basic authentication so non-existent users follow the same dummy-check flow, reducing differences between valid and invalid username attempts.

* **Tests**
  * Updated authentication-related test setups to fail fast if authentication service initialization returns an error, before running controller and middleware tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->