### PR TITLE
fix: abstain when OAuth whitelist is empty

### DIFF
--- a/internal/service/access_controls_rules.go
+++ b/internal/service/access_controls_rules.go
@@ -43,6 +43,11 @@ func (rule *UserAllowedRule) Evaluate(ctx *ACLContext) Effect {
 		rule.Log.App.Debug().Msg("User is an OAuth user, checking OAuth whitelist")
 		match, err := utils.CheckFilter(ctx.ACLs.OAuth.Whitelist, ctx.UserContext.OAuth.Email)
 		if err != nil {
+			// Empty whitelist means "not configured" — let OAuth group rules decide.
+			if err == utils.ErrFilterEmpty {
+				rule.Log.App.Debug().Msg("OAuth whitelist is empty, abstaining")
+				return EffectAbstain
+			}
 			rule.Log.App.Warn().Err(err).Str("item", ctx.UserContext.OAuth.Email).Msg("Invalid entry in OAuth whitelist")
 			return EffectDeny
 		}


### PR DESCRIPTION
## What

Treat an empty OAuth whitelist as unconfigured (abstain) instead of denying access.

## Why

In v5.1.0, apps configured with only `OAUTH_GROUPS` (no `OAUTH_WHITELIST`) fail with `filter is empty` and deny all OAuth users. Groups-based access control never gets a chance to allow them.

Closes #1009

## Changes

- `UserAllowedRule`: on `utils.ErrFilterEmpty` for OAuth whitelist, return `EffectAbstain` (same pattern as empty users allow list)
- Invalid non-empty filters still deny

## Verification

- Configure app with OAuth groups only, no whitelist
- OAuth user in allowed group should be permitted
- Non-empty whitelist still allows/denies by email match


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty OAuth whitelists are now handled correctly without incorrectly denying access.
  * Access evaluation abstains when no OAuth whitelist entries are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->