### PR TITLE
fix(ldap): use DN instead of uid in basicAuth GetLDAPUser call

### DIFF
--- a/internal/middleware/context_middleware.go
+++ b/internal/middleware/context_middleware.go
@@ -282,7 +282,7 @@ func (m *ContextMiddleware) basicAuth(username string, password string) (*model.
 		}
 		userContext.Provider = model.ProviderLocal
 	case model.UserLDAP:
-		user, err := m.auth.GetLDAPUser(username)
+		user, err := m.auth.GetLDAPUser(search.Username)
 
 		if err != nil {
 			return nil, nil, fmt.Errorf("error retrieving ldap user details: %w", err)


### PR DESCRIPTION
## Problem

`basicAuth` and `cookieAuth` both call `SearchUser` to resolve an incoming username, then call `GetLDAPUser` with the result — but they pass different arguments:

| Function | Argument passed to `GetLDAPUser` |
|---|---|
| `cookieAuth` (LDAP branch, line 197) | `search.Username` (the DN returned by `SearchUser`) |
| `basicAuth` (LDAP branch, line 285) | `username` (the raw uid from the HTTP `Authorization` header) |

`GetLDAPUser` builds a group-membership query using `uniquemember=<value>`. LDAP `uniquemember` attributes store full Distinguished Names (e.g. `uid=alice,ou=users,dc=example,dc=com`), not bare uids. Passing a raw uid produces zero matches, so `user.Groups` is always empty for any LDAP user authenticating via Basic Auth. All group-based ACL rules are silently bypassed or denied depending on policy.

`cookieAuth` has the correct pattern: it uses `search.Username`, which is the DN that `SearchUser` returns. `basicAuth` should do the same.

## Fix

One-line change in `internal/middleware/context_middleware.go`, `basicAuth` LDAP case:

```go
// before
user, err := m.auth.GetLDAPUser(username)

// after
user, err := m.auth.GetLDAPUser(search.Username)
```

`search` is already in scope — it is the `*model.UserSearch` returned by the `SearchUser` call earlier in the same function.

Closes #848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LDAP authentication by consistently using the authenticated username when retrieving user details.
  * Helps ensure the correct LDAP user context is created during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->