### PR TITLE
fix: stop forwarding client Authorization header to downstream apps

### DIFF
--- a/internal/controller/proxy_controller.go
+++ b/internal/controller/proxy_controller.go
@@ -305,8 +305,6 @@ func (controller *ProxyController) proxyHandler(c *gin.Context) {
 }
 
 func (controller *ProxyController) setHeaders(c *gin.Context, acls *model.App) {
-	c.Header("Authorization", c.Request.Header.Get("Authorization"))
-
 	if acls == nil {
 		return
 	}


### PR DESCRIPTION
setHeaders was piping the client's Authorization header straight through to the downstream app on every request. if someone auths via Basic Auth their creds end up in the backend. even with session-based auth, any Authorization header the client sent gets leaked.

the configured Basic Auth passthrough from ACLs is untouched, it still sets its own header separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incoming authorization credentials from being exposed in proxy responses.
  * Responses now include only configured access-control headers and applicable authentication headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->