### PR TITLE
fix: clean request path before acls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,9 +132,9 @@ TINYAUTH_APPS_name_RESPONSE_BASICAUTH_USERNAME=
 TINYAUTH_APPS_name_RESPONSE_BASICAUTH_PASSWORD=
 # Path to the file containing the basic auth password.
 TINYAUTH_APPS_name_RESPONSE_BASICAUTH_PASSWORDFILE=
-# Comma-separated list of allowed paths.
+# Disable authentication for only paths that match the regex string.
 TINYAUTH_APPS_name_PATH_ALLOW=
-# Comma-separated list of blocked paths.
+# Enable authentication for only paths that match the regex string.
 TINYAUTH_APPS_name_PATH_BLOCK=
 # Comma-separated list of required LDAP groups.
 TINYAUTH_APPS_name_LDAP_GROUPS=

--- a/internal/controller/proxy_controller.go
+++ b/internal/controller/proxy_controller.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -550,6 +551,19 @@ func (controller *ProxyController) getProxyContext(c *gin.Context) (ProxyContext
 	if err != nil {
 		return ProxyContext{}, err
 	}
+
+	// remove any query params from the request path
+	upath, err := url.Parse(ctx.Path)
+
+	if err != nil {
+		return ProxyContext{}, fmt.Errorf("failed to parse request path: %v", err)
+	}
+
+	if upath.Host != "" || !strings.HasPrefix(upath.Path, "/") {
+		return ProxyContext{}, fmt.Errorf("invalid request path")
+	}
+
+	ctx.Path = path.Clean(upath.Path)
 
 	// We don't care if the header is empty, we will just assume it's not a browser
 	userAgent, _ := controller.getHeader(c, "user-agent")

--- a/internal/controller/proxy_controller_test.go
+++ b/internal/controller/proxy_controller_test.go
@@ -309,6 +309,171 @@ func TestProxyController(t *testing.T) {
 			},
 		},
 		{
+			description: "Ensure path block ACL requires auth on exact match",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/admin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL skips auth for non-matching path",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/public")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusOK, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with query params",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/admin?foo=bar")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with a trailing slash",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/admin/")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with dot segments",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/foo/../admin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with percent-encoded characters",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/%61dmin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with a percent-encoded double slash",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/%2Fadmin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure a protocol-relative x-forwarded-uri is rejected",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "//admin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure a relative x-forwarded-uri is rejected",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-block.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "public")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with query params on envoy ext authz",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("HEAD", "/api/auth/envoy?path=/admin%3Ffoo=bar", nil)
+				req.Host = "path-block.example.com"
+				req.Header.Set("x-forwarded-proto", "https")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path block ACL cannot be bypassed with dot segments on nginx auth request",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/nginx", nil)
+				req.Header.Set("x-original-url", "https://path-block.example.com/foo/../admin")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path allow ACL still matches when query params are present",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-allow.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/allowed?foo=bar")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusOK, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure path allow ACL cannot be extended with dot segments",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-allow.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/allowed/../secret")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			description: "Ensure an allowed path inside the query string does not bypass auth",
+			middlewares: []gin.HandlerFunc{},
+			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {
+				req := httptest.NewRequest("GET", "/api/auth/traefik", nil)
+				req.Header.Set("x-forwarded-host", "path-allow.example.com")
+				req.Header.Set("x-forwarded-proto", "https")
+				req.Header.Set("x-forwarded-uri", "/secret?next=/allowed")
+				router.ServeHTTP(recorder, req)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
 			description: "Ensure ip bypass ACL works on forward auth",
 			middlewares: []gin.HandlerFunc{},
 			run: func(t *testing.T, router *gin.Engine, recorder *httptest.ResponseRecorder) {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -332,6 +332,6 @@ type AppBasicAuth struct {
 }
 
 type AppPath struct {
-	Allow string `description:"Comma-separated list of allowed paths." yaml:"allow,omitempty"`
-	Block string `description:"Comma-separated list of blocked paths." yaml:"block,omitempty"`
+	Allow string `description:"Disable authentication for only paths that match the regex string." yaml:"allow,omitempty"`
+	Block string `description:"Enable authentication for only paths that match the regex string." yaml:"block,omitempty"`
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -58,7 +58,15 @@ func CreateTestConfigs(t *testing.T) (model.Config, model.RuntimeConfig) {
 					Domain: "path-allow.example.com",
 				},
 				Path: model.AppPath{
-					Allow: "/allowed",
+					Allow: "^/allowed$",
+				},
+			},
+			"app_path_block": {
+				Config: model.AppConfig{
+					Domain: "path-block.example.com",
+				},
+				Path: model.AppPath{
+					Block: "^/admin$",
 				},
 			},
 			"app_user_allow": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved path validation and normalization to prevent authentication bypasses using malformed paths, query parameters, encoded characters, or dot-segment variations.
  * Strengthened path-based allow and block rules across supported proxy integrations.

* **Documentation**
  * Clarified that path rules use regular expressions to enable or disable authentication for matching paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->